### PR TITLE
Catch faders

### DIFF
--- a/src/block_implementations/Eos/EosFaderBankBlock.cpp
+++ b/src/block_implementations/Eos/EosFaderBankBlock.cpp
@@ -13,6 +13,7 @@ EosFaderBankBlock::EosFaderBankBlock(MainController* controller, QString uid)
     , m_externalLevels(10)
     , m_externalLevelsValid(10, false)
     , m_faderSync(10, false)
+    , m_feedbackValid(10, true)
     , m_catchFaders(this, "catchFaders", true)
 {
     connect(m_controller->eosManager(), SIGNAL(connectionEstablished()),
@@ -47,6 +48,10 @@ void EosFaderBankBlock::setPageFromGui(int value) {
 void EosFaderBankBlock::setFaderLabelFromOsc(int faderIndex, QString label) {
     if (faderIndex < 0 || faderIndex > 9) return;
     m_faderLabels[faderIndex] = label;
+    if (label == "Global FX" || label == "Man Time")
+        m_feedbackValid[faderIndex] = false;
+    else
+        m_feedbackValid[faderIndex] = true;
     emit faderLabelsChanged();
 }
 
@@ -95,6 +100,8 @@ void EosFaderBankBlock::setFaderLevelFromExt(int faderIndex, qreal value) {
 
 void EosFaderBankBlock::setFaderLevelFromOsc(int faderIndex, qreal value){
     if (faderIndex < 0 || faderIndex > 9) return;
+    if (!m_feedbackValid[faderIndex]) return;
+
     m_faderLevels[faderIndex] = limit(0, value, 1);
 
     // asynchronous osc feedback can break sync so give it some time

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -70,6 +70,8 @@ public slots:
     void sendPageMinusEvent();
     void sendPagePlusEvent();
 
+    void updateFaderCount();
+
 protected slots:
     void onEosConnectionEstablished();
     void sendConfigMessage();
@@ -85,12 +87,14 @@ protected:
     int m_page;
     QString m_bankLabel;
 
+    IntegerAttribute m_numFaders;
+
     QVector<QString> m_faderLabels;
     QVector<qreal> m_faderLevels;
     QVector<qreal> m_externalLevels;
     QVector<bool> m_externalLevelsValid;
     QVector<bool> m_faderSync;
-    QVector<bool> m_feedbackValid;
+    QVector<bool> m_feedbackInvalid;
 
     BoolAttribute m_catchFaders;
     QTime m_lastExtTime;

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -1,6 +1,7 @@
 #ifndef EOSFADERBANKBLOCK_H
 #define EOSFADERBANKBLOCK_H
 
+#include <QDateTime>
 #include "core/block_data/BlockBase.h"
 #include "eos_specific/EosOSCMessage.h"
 #include "utils.h"
@@ -91,6 +92,7 @@ protected:
     QVector<bool> m_faderSync;
 
     BoolAttribute m_catchFaders;
+    QTime m_lastExtTime;
 };
 
 #endif // EOSFADERBANKBLOCK_H

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -56,7 +56,9 @@ public slots:
     void setFaderLabelFromOsc(int faderIndex, QString label);
 
     QList<qreal> getFaderLevels() const { return m_faderLevels.toList(); }
+    void setFaderLevel(int faderIndex, qreal value);
     void setFaderLevelFromGui(int faderIndex, qreal value);
+    void setFaderLevelFromExt(int faderIndex, qreal value);
     void setFaderLevelFromOsc(int faderIndex, qreal value);
 
     void sendLoadEvent(int faderIndex, bool value);
@@ -84,6 +86,11 @@ protected:
 
     QVector<QString> m_faderLabels;
     QVector<qreal> m_faderLevels;
+    QVector<qreal> m_externalLevels;
+    QVector<bool> m_externalLevelsValid;
+    QVector<bool> m_faderSync;
+
+    BoolAttribute m_catchFaders;
 };
 
 #endif // EOSFADERBANKBLOCK_H

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -90,6 +90,7 @@ protected:
     QVector<qreal> m_externalLevels;
     QVector<bool> m_externalLevelsValid;
     QVector<bool> m_faderSync;
+    QVector<bool> m_feedbackValid;
 
     BoolAttribute m_catchFaders;
     QTime m_lastExtTime;

--- a/src/qml/Blocks/Eos/EosFaderBankBlock.qml
+++ b/src/qml/Blocks/Eos/EosFaderBankBlock.qml
@@ -8,6 +8,8 @@ BlockBase {
     id: root
     width: 90*10*dp
     height: 400*dp
+    settingsComponent: settings
+
 
     StretchColumn {
         anchors.fill: parent
@@ -62,4 +64,24 @@ BlockBase {
         }
 
     }  // end main Column
+
+    Component {
+        id: settings
+        StretchColumn {
+            leftMargin: 15*dp
+            rightMargin: 15*dp
+            defaultSize: 30*dp
+
+            BlockRow {
+                Text {
+                    text: "Catch external faders:"
+                    width: parent.width - 30*dp
+                }
+                AttributeCheckbox {
+                    width: 30*dp
+                    attr: block.attr("catchFaders")
+                }
+            }
+        }
+    }  // end Settings Component
 }

--- a/src/qml/Blocks/Eos/EosFaderBankBlock.qml
+++ b/src/qml/Blocks/Eos/EosFaderBankBlock.qml
@@ -6,7 +6,7 @@ import "../../."  // to import EosFaderItem
 
 BlockBase {
     id: root
-    width: 90*10*dp
+    width: (block.attr("numFaders").val)*90*dp
     height: 400*dp
     settingsComponent: settings
 
@@ -18,7 +18,8 @@ BlockBase {
             implicitHeight: -1
 
             Repeater {
-                model: 10
+                id: faderRepeater
+                model: block.attr("numFaders").val
 
                 EosFaderItem {
                     index: modelData
@@ -80,6 +81,16 @@ BlockBase {
                 AttributeCheckbox {
                     width: 30*dp
                     attr: block.attr("catchFaders")
+                }
+            }
+            BlockRow {
+                StretchText {
+                    text: "Faders count:"
+                }
+                AttributeNumericInput {
+                    width:  55*dp
+                    implicitWidth: 0
+                    attr: block.attr("numFaders")
                 }
             }
         }

--- a/src/qml/CustomControls/Slider.qml
+++ b/src/qml/CustomControls/Slider.qml
@@ -10,6 +10,7 @@ CustomTouchArea {
     // public attributes:
     property int padding: 20*dp
     property real value: 0.0
+    property real externalValue: 0.0
 	property real indicator: 0.0
     property bool useIndicator: false
     property bool midiMappingEnabled: true
@@ -92,7 +93,7 @@ CustomTouchArea {
     Component.onCompleted: controller.midiMapping().registerGuiControl(this, mappingID)
     Component.onDestruction: if (controller) controller.midiMapping().unregisterGuiControl(mappingID)
     onExternalInputChanged: {
-        guiManager.setPropertyWithoutChangingBindings(this, "value", externalInput)
+        guiManager.setPropertyWithoutChangingBindings(this, "externalValue", externalInput)
     }
     onValueChanged: controller.midiMapping().sendFeedback(mappingID, value)
 }

--- a/src/qml/EosFaderItem.qml
+++ b/src/qml/EosFaderItem.qml
@@ -51,6 +51,11 @@ StretchColumn {
                 block.setFaderLevelFromGui(index, value)
             }
         }
+        onExternalValueChanged: {
+            if (externalValue !== block.faderLevels[index]) {
+                block.setFaderLevelFromExt(index, externalValue)
+            }
+        }
         mappingID: block.getUid() + "fader" + modelData
     }
     PushButton {


### PR DESCRIPTION
Using fader pages with non motorized faders (korg nano) is a pain. This implements catching feature where you need to catch the correct value with your physical fader before it starts sending output.
I noticed that if Luminosus and EOS are not on same machine and network connection is slow (wifi) then EOS osc feedback is not always synchronized correctly and then this feature does not work well (flag signalizing that fader is caught get sometimes reset unwantedly). On good connection or same machine (most common setup probably) there is no issues.