### PR TITLE
Small improvements for using luminosus in theatre

### DIFF
--- a/src/RtMidi/RtMidi.cpp
+++ b/src/RtMidi/RtMidi.cpp
@@ -5,10 +5,11 @@
     This class implements some common functionality for the realtime
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
-    RtMidi WWW site: http://music.mcgill.ca/~gary/rtmidi/
+    RtMidi GitHub site: https://github.com/thestk/rtmidi
+    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
-    Copyright (c) 2003-2016 Gary P. Scavone
+    Copyright (c) 2003-2019 Gary P. Scavone
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation files
@@ -36,6 +37,8 @@
 */
 /**********************************************************************/
 
+#define __RTMIDI_DEBUG__
+
 #include "RtMidi.h"
 #include <sstream>
 
@@ -44,6 +47,229 @@
     #define AudioGetCurrentHostTime CAHostTimeBase::GetCurrentTime
     #define AudioConvertHostTimeToNanos CAHostTimeBase::ConvertToNanos
   #endif
+#endif
+
+// Default for Windows is to add an identifier to the port names; this
+// flag can be defined (e.g. in your project file) to disable this behaviour.
+//#define RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
+
+// **************************************************************** //
+//
+// MidiInApi and MidiOutApi subclass prototypes.
+//
+// **************************************************************** //
+
+#if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
+  #define __RTMIDI_DUMMY__
+#endif
+
+#if defined(__MACOSX_CORE__)
+
+class MidiInCore: public MidiInApi
+{
+ public:
+  MidiInCore( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInCore( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutCore: public MidiOutApi
+{
+ public:
+  MidiOutCore( const std::string &clientName );
+  ~MidiOutCore( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__UNIX_JACK__)
+
+class MidiInJack: public MidiInApi
+{
+ public:
+  MidiInJack( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInJack( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  std::string clientName;
+
+  void connect( void );
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutJack: public MidiOutApi
+{
+ public:
+  MidiOutJack( const std::string &clientName );
+  ~MidiOutJack( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  std::string clientName;
+
+  void connect( void );
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__LINUX_ALSA__)
+
+class MidiInAlsa: public MidiInApi
+{
+ public:
+  MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInAlsa( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutAlsa: public MidiOutApi
+{
+ public:
+  MidiOutAlsa( const std::string &clientName );
+  ~MidiOutAlsa( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__WINDOWS_MM__)
+
+class MidiInWinMM: public MidiInApi
+{
+ public:
+  MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInWinMM( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutWinMM: public MidiOutApi
+{
+ public:
+  MidiOutWinMM( const std::string &clientName );
+  ~MidiOutWinMM( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__RTMIDI_DUMMY__)
+
+class MidiI nDummy: public MidiInApi
+{
+ public:
+ MidiInDummy( const std::string &/*clientName*/, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit ) { errorString_ = "MidiInDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
+  void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
+  void openVirtualPort( const std::string &/*portName*/ ) {}
+  void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
+  void setPortName( const std::string &/*portName*/ ) {};
+  unsigned int getPortCount( void ) { return 0; }
+  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
+
+ protected:
+  void initialize( const std::string& /*clientName*/ ) {}
+};
+
+class MidiOutDummy: public MidiOutApi
+{
+ public:
+  MidiOutDummy( const std::string &/*clientName*/ ) { errorString_ = "MidiOutDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
+  void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
+  void openVirtualPort( const std::string &/*portName*/ ) {}
+  void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
+  void setPortName( const std::string &/*portName*/ ) {};
+  unsigned int getPortCount( void ) { return 0; }
+  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
+  void sendMessage( const unsigned char * /*message*/, size_t /*size*/ ) {}
+
+ protected:
+  void initialize( const std::string& /*clientName*/ ) {}
+};
+
 #endif
 
 //*********************************************************************//
@@ -57,8 +283,7 @@ RtMidi :: RtMidi()
 
 RtMidi :: ~RtMidi()
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 }
 
@@ -67,37 +292,99 @@ std::string RtMidi :: getVersion( void ) throw()
   return std::string( RTMIDI_VERSION );
 }
 
-void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
-{
-  apis.clear();
+// Define API names and display names.
+// Must be in same order as API enum.
+extern "C" {
+const char* rtmidi_api_names[][2] = {
+  { "unspecified" , "Unknown" },
+  { "core"        , "CoreMidi" },
+  { "alsa"        , "ALSA" },
+  { "jack"        , "Jack" },
+  { "winmm"       , "Windows MultiMedia" },
+  { "dummy"       , "Dummy" },
+};
+const unsigned int rtmidi_num_api_names =
+  sizeof(rtmidi_api_names)/sizeof(rtmidi_api_names[0]);
 
-  // The order here will control the order of RtMidi's API search in
-  // the constructor.
+// The order here will control the order of RtMidi's API search in
+// the constructor.
+extern "C" const RtMidi::Api rtmidi_compiled_apis[] = {
 #if defined(__MACOSX_CORE__)
-  apis.push_back( MACOSX_CORE );
+  RtMidi::MACOSX_CORE,
 #endif
 #if defined(__LINUX_ALSA__)
-  apis.push_back( LINUX_ALSA );
+  RtMidi::LINUX_ALSA,
 #endif
 #if defined(__UNIX_JACK__)
-  apis.push_back( UNIX_JACK );
+  RtMidi::UNIX_JACK,
 #endif
 #if defined(__WINDOWS_MM__)
-  apis.push_back( WINDOWS_MM );
+  RtMidi::WINDOWS_MM,
 #endif
 #if defined(__RTMIDI_DUMMY__)
-  apis.push_back( RTMIDI_DUMMY );
+  RtMidi::RTMIDI_DUMMY,
 #endif
+  RtMidi::UNSPECIFIED,
+};
+extern "C" const unsigned int rtmidi_num_compiled_apis =
+  sizeof(rtmidi_compiled_apis)/sizeof(rtmidi_compiled_apis[0])-1;
 }
+
+// This is a compile-time check that rtmidi_num_api_names == RtMidi::NUM_APIS.
+// If the build breaks here, check that they match.
+template<bool b> class StaticAssert { private: StaticAssert() {} };
+template<> class StaticAssert<true>{ public: StaticAssert() {} };
+class StaticAssertions { StaticAssertions() {
+  StaticAssert<rtmidi_num_api_names == RtMidi::NUM_APIS>();
+}};
+
+void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
+{
+  apis = std::vector<RtMidi::Api>(rtmidi_compiled_apis,
+                                  rtmidi_compiled_apis + rtmidi_num_compiled_apis);
+}
+
+std::string RtMidi :: getApiName( RtMidi::Api api )
+{
+  if (api < 0 || api >= RtMidi::NUM_APIS)
+    return "";
+  return rtmidi_api_names[api][0];
+}
+
+std::string RtMidi :: getApiDisplayName( RtMidi::Api api )
+{
+  if (api < 0 || api >= RtMidi::NUM_APIS)
+    return "Unknown";
+  return rtmidi_api_names[api][1];
+}
+
+RtMidi::Api RtMidi :: getCompiledApiByName( const std::string &name )
+{
+  unsigned int i=0;
+  for (i = 0; i < rtmidi_num_compiled_apis; ++i)
+    if (name == rtmidi_api_names[rtmidi_compiled_apis[i]][0])
+      return rtmidi_compiled_apis[i];
+  return RtMidi::UNSPECIFIED;
+}
+
+void RtMidi :: setClientName( const std::string &clientName )
+{
+  rtapi_->setClientName( clientName );
+}
+
+void RtMidi :: setPortName( const std::string &portName )
+{
+  rtapi_->setPortName( portName );
+}
+
 
 //*********************************************************************//
 //  RtMidiIn Definitions
 //*********************************************************************//
 
-void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit )
+void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 
 #if defined(__UNIX_JACK__)
@@ -122,7 +409,7 @@ void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string clientName, uns
 #endif
 }
 
-RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit )
+RTMIDI_DLL_PUBLIC RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
   : RtMidi()
 {
   if ( api != UNSPECIFIED ) {
@@ -141,7 +428,7 @@ RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string clientName, unsigned in
   getCompiledApi( apis );
   for ( unsigned int i=0; i<apis.size(); i++ ) {
     openMidiApi( apis[i], clientName, queueSizeLimit );
-    if ( rtapi_->getPortCount() ) break;
+    if ( rtapi_ && rtapi_->getPortCount() ) break;
   }
 
   if ( rtapi_ ) return;
@@ -163,10 +450,9 @@ RtMidiIn :: ~RtMidiIn() throw()
 //  RtMidiOut Definitions
 //*********************************************************************//
 
-void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string clientName )
+void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string &clientName )
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 
 #if defined(__UNIX_JACK__)
@@ -191,7 +477,7 @@ void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string clientName )
 #endif
 }
 
-RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string clientName )
+RTMIDI_DLL_PUBLIC RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string &clientName)
 {
   if ( api != UNSPECIFIED ) {
     // Attempt to open the specified API.
@@ -209,7 +495,7 @@ RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string clientName )
   getCompiledApi( apis );
   for ( unsigned int i=0; i<apis.size(); i++ ) {
     openMidiApi( apis[i], clientName );
-    if ( rtapi_->getPortCount() ) break;
+    if ( rtapi_ && rtapi_->getPortCount() ) break;
   }
 
   if ( rtapi_ ) return;
@@ -231,7 +517,7 @@ RtMidiOut :: ~RtMidiOut() throw()
 //*********************************************************************//
 
 MidiApi :: MidiApi( void )
-  : apiData_( 0 ), connected_( false ), errorCallback_(0), errorCallbackUserData_(0)
+  : apiData_( 0 ), connected_( false ), errorCallback_(0), firstErrorOccurred_(false), errorCallbackUserData_(0)
 {
 }
 
@@ -255,7 +541,7 @@ void MidiApi :: error( RtMidiError::Type type, std::string errorString )
     firstErrorOccurred_ = true;
     const std::string errorMessage = errorString;
 
-    errorCallback_( type, errorMessage, errorCallbackUserData_);
+    errorCallback_( type, errorMessage, errorCallbackUserData_ );
     firstErrorOccurred_ = false;
     return;
   }
@@ -343,18 +629,68 @@ double MidiInApi :: getMessage( std::vector<unsigned char> *message )
     return 0.0;
   }
 
-  if ( inputData_.queue.size == 0 ) return 0.0;
+  double timeStamp;
+  if ( !inputData_.queue.pop( message, &timeStamp ) )
+    return 0.0;
+
+  return timeStamp;
+}
+
+unsigned int MidiInApi::MidiQueue::size( unsigned int *__back,
+                                         unsigned int *__front )
+{
+  // Access back/front members exactly once and make stack copies for
+  // size calculation
+  unsigned int _back = back, _front = front, _size;
+  if ( _back >= _front )
+    _size = _back - _front;
+  else
+    _size = ringSize - _front + _back;
+
+  // Return copies of back/front so no new and unsynchronized accesses
+  // to member variables are needed.
+  if ( __back ) *__back = _back;
+  if ( __front ) *__front = _front;
+  return _size;
+}
+
+// As long as we haven't reached our queue size limit, push the message.
+bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
+{
+  // Local stack copies of front/back
+  unsigned int _back, _front, _size;
+
+  // Get back/front indexes exactly once and calculate current size
+  _size = size( &_back, &_front );
+
+  if ( _size < ringSize-1 )
+  {
+    ring[_back] = msg;
+    back = (back+1)%ringSize;
+    return true;
+  }
+
+  return false;
+}
+
+bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeStamp )
+{
+  // Local stack copies of front/back
+  unsigned int _back, _front, _size;
+
+  // Get back/front indexes exactly once and calculate current size
+  _size = size( &_back, &_front );
+
+  if ( _size == 0 )
+    return false;
 
   // Copy queued message to the vector pointer argument and then "pop" it.
-  std::vector<unsigned char> *bytes = &(inputData_.queue.ring[inputData_.queue.front].bytes);
-  message->assign( bytes->begin(), bytes->end() );
-  double deltaTime = inputData_.queue.ring[inputData_.queue.front].timeStamp;
-  inputData_.queue.size--;
-  inputData_.queue.front++;
-  if ( inputData_.queue.front == inputData_.queue.ringSize )
-    inputData_.queue.front = 0;
+  msg->assign( ring[_front].bytes.begin(), ring[_front].bytes.end() );
+  *timeStamp = ring[_front].timeStamp;
 
-  return deltaTime;
+  // Update front
+  front = (front+1)%ringSize;
+  return true;
 }
 
 //*********************************************************************//
@@ -428,10 +764,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
     // function.
 
     nBytes = packet->length;
-    if ( nBytes == 0 ) continue;
+    if ( nBytes == 0 ) {
+      packet = MIDIPacketNext( packet );
+      continue;
+    }
 
     // Calculate time stamp.
-
     if ( data->firstMessage ) {
       message.timeStamp = 0.0;
       data->firstMessage = false;
@@ -446,11 +784,10 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
       if ( !continueSysex )
         message.timeStamp = time * 0.000000001;
     }
-    apiData->lastTime = packet->timeStamp;
-    if ( apiData->lastTime == 0 ) { // this happens when receiving asynchronous sysex messages
-      apiData->lastTime = AudioGetCurrentHostTime();
-    }
-    //std::cout << "TimeStamp = " << packet->timeStamp << std::endl;
+
+    // Track whether any non-filtered messages were found in this
+    // packet for timestamp calculation
+    bool foundNonFiltered = false;
 
     iByte = 0;
     if ( continueSysex ) {
@@ -470,13 +807,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
         else {
           // As long as we haven't reached our queue size limit, push the message.
-          if ( data->queue.size < data->queue.ringSize ) {
-            data->queue.ring[data->queue.back++] = message;
-            if ( data->queue.back == data->queue.ringSize )
-              data->queue.back = 0;
-            data->queue.size++;
-          }
-          else
+          if ( !data->queue.push( message ) )
             std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
         }
         message.bytes.clear();
@@ -502,12 +833,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
           continueSysex = packet->data[nBytes-1] != 0xF7;
         }
         else if ( status == 0xF1 ) {
-            // A MIDI time code message
-           if ( data->ignoreFlags & 0x02 ) {
+          // A MIDI time code message
+          if ( data->ignoreFlags & 0x02 ) {
             size = 0;
             iByte += 2;
-           }
-           else size = 2;
+          }
+          else size = 2;
         }
         else if ( status == 0xF2 ) size = 3;
         else if ( status == 0xF3 ) size = 2;
@@ -525,6 +856,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
 
         // Copy the MIDI data to our vector.
         if ( size ) {
+          foundNonFiltered = true;
           message.bytes.assign( &packet->data[iByte], &packet->data[iByte+size] );
           if ( !continueSysex ) {
             // If not a continuing sysex message, invoke the user callback function or queue the message.
@@ -534,13 +866,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
             }
             else {
               // As long as we haven't reached our queue size limit, push the message.
-              if ( data->queue.size < data->queue.ringSize ) {
-                data->queue.ring[data->queue.back++] = message;
-                if ( data->queue.back == data->queue.ringSize )
-                  data->queue.back = 0;
-                data->queue.size++;
-              }
-              else
+              if ( !data->queue.push( message ) )
                 std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
             }
             message.bytes.clear();
@@ -549,19 +875,29 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
       }
     }
+
+    // Save the time of the last non-filtered message
+    if ( foundNonFiltered ) {
+      apiData->lastTime = packet->timeStamp;
+      if ( apiData->lastTime == 0 ) { // this happens when receiving asynchronous sysex messages
+        apiData->lastTime = AudioGetCurrentHostTime();
+      }
+    }
+
     packet = MIDIPacketNext(packet);
   }
 }
 
-MidiInCore :: MidiInCore( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInCore :: MidiInCore( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInCore::initialize( clientName );
 }
 
 MidiInCore :: ~MidiInCore( void )
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInCore::closePort();
 
   // Cleanup.
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
@@ -577,7 +913,9 @@ void MidiInCore :: initialize( const std::string& clientName )
   CFStringRef name = CFStringCreateWithCString( NULL, clientName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIClientCreate(name, NULL, NULL, &client );
   if ( result != noErr ) {
-    errorString_ = "MidiInCore::initialize: error creating OS-X MIDI client object.";
+    std::ostringstream ost;
+    ost << "MidiInCore::initialize: error creating OS-X MIDI client object (" << result << ").";
+    errorString_ = ost.str();
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -588,10 +926,10 @@ void MidiInCore :: initialize( const std::string& clientName )
   data->endpoint = 0;
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
-  CFRelease(name);
+  CFRelease( name );
 }
 
-void MidiInCore :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInCore :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiInCore::openPort: a valid connection already exists!";
@@ -601,7 +939,7 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
   CFRunLoopRunInMode( kCFRunLoopDefaultMode, 0, false );
   unsigned int nSrc = MIDIGetNumberOfSources();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiInCore::openPort: no MIDI input sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -617,9 +955,12 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-  OSStatus result = MIDIInputPortCreate( data->client, 
-                                         CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDIInputPortCreate( data->client,
+                                         portNameRef,
                                          midiInputCallback, (void *)&inputData_, &port );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
     errorString_ = "MidiInCore::openPort: error creating OS-X MIDI input port.";
@@ -653,15 +994,18 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
   connected_ = true;
 }
 
-void MidiInCore :: openVirtualPort( const std::string portName )
+void MidiInCore :: openVirtualPort( const std::string &portName )
 {
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   // Create a virtual MIDI input destination.
   MIDIEndpointRef endpoint;
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIDestinationCreate( data->client,
-                                           CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
+                                           portNameRef,
                                            midiInputCallback, (void *)&inputData_, &endpoint );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     errorString_ = "MidiInCore::openVirtualPort: error creating virtual OS-X MIDI destination.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -678,13 +1022,31 @@ void MidiInCore :: closePort( void )
 
   if ( data->endpoint ) {
     MIDIEndpointDispose( data->endpoint );
+    data->endpoint = 0;
   }
 
   if ( data->port ) {
     MIDIPortDispose( data->port );
+    data->port = 0;
   }
 
   connected_ = false;
+}
+
+void MidiInCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInCore :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiInCore::setPortName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 unsigned int MidiInCore :: getPortCount()
@@ -749,12 +1111,13 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
       // does the entity name already start with the device name?
       // (some drivers do this though they shouldn't)
       // if so, do not prepend
-        if ( CFStringCompareWithOptions( result, /* endpoint name */
-             str /* device name */,
-             CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
+      if ( CFStringCompareWithOptions( result, /* endpoint name */
+                                       str /* device name */,
+                                       CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
         // prepend the device name to the entity name
         if ( CFStringGetLength( result ) > 0 )
           CFStringInsert( result, 0, CFSTR(" ") );
+
         CFStringInsert( result, 0, str );
       }
       CFRelease( str );
@@ -790,7 +1153,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
         err = MIDIObjectFindByUniqueID( id, &connObject, &connObjectType );
         if ( err == noErr ) {
           if ( connObjectType == kMIDIObjectType_ExternalSource  ||
-              connObjectType == kMIDIObjectType_ExternalDestination ) {
+               connObjectType == kMIDIObjectType_ExternalDestination ) {
             // Connected to an external device's endpoint (10.3 and later).
             str = EndpointName( (MIDIEndpointRef)(connObject), true );
           } else {
@@ -801,7 +1164,8 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
           if ( str != NULL ) {
             if ( anyStrings )
               CFStringAppend( result, CFSTR(", ") );
-            else anyStrings = true;
+            else
+              anyStrings = true;
             CFStringAppend( result, str );
             CFRelease( str );
           }
@@ -815,7 +1179,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
 
   CFRelease( result );
 
-  // Here, either the endpoint had no connections, or we failed to obtain names 
+  // Here, either the endpoint had no connections, or we failed to obtain names
   return EndpointName( endpoint, false );
 }
 
@@ -836,8 +1200,8 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
   }
 
   portRef = MIDIGetSource( portNumber );
-  nameRef = ConnectedEndpointName(portRef);
-  CFStringGetCString( nameRef, name, sizeof(name), CFStringGetSystemEncoding());
+  nameRef = ConnectedEndpointName( portRef );
+  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
 
   return stringName = name;
@@ -848,15 +1212,16 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
 //  Class Definitions: MidiOutCore
 //*********************************************************************//
 
-MidiOutCore :: MidiOutCore( const std::string clientName ) : MidiOutApi()
+MidiOutCore :: MidiOutCore( const std::string &clientName )
+  : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutCore::initialize( clientName );
 }
 
 MidiOutCore :: ~MidiOutCore( void )
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutCore::closePort();
 
   // Cleanup.
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
@@ -872,7 +1237,9 @@ void MidiOutCore :: initialize( const std::string& clientName )
   CFStringRef name = CFStringCreateWithCString( NULL, clientName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIClientCreate(name, NULL, NULL, &client );
   if ( result != noErr ) {
-    errorString_ = "MidiOutCore::initialize: error creating OS-X MIDI client object.";
+    std::ostringstream ost;
+    ost << "MidiInCore::initialize: error creating OS-X MIDI client object (" << result << ").";
+    errorString_ = ost.str();
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -909,13 +1276,13 @@ std::string MidiOutCore :: getPortName( unsigned int portNumber )
 
   portRef = MIDIGetDestination( portNumber );
   nameRef = ConnectedEndpointName(portRef);
-  CFStringGetCString( nameRef, name, sizeof(name), CFStringGetSystemEncoding());
+  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
-  
+
   return stringName = name;
 }
 
-void MidiOutCore :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutCore :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutCore::openPort: a valid connection already exists!";
@@ -941,9 +1308,9 @@ void MidiOutCore :: openPort( unsigned int portNumber, const std::string portNam
 
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-  OSStatus result = MIDIOutputPortCreate( data->client, 
-                                          CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
-                                          &port );
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDIOutputPortCreate( data->client, portNameRef, &port );
+  CFRelease( portNameRef );
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
     errorString_ = "MidiOutCore::openPort: error creating OS-X MIDI output port.";
@@ -973,16 +1340,34 @@ void MidiOutCore :: closePort( void )
 
   if ( data->endpoint ) {
     MIDIEndpointDispose( data->endpoint );
+    data->endpoint = 0;
   }
 
   if ( data->port ) {
     MIDIPortDispose( data->port );
+    data->port = 0;
   }
 
   connected_ = false;
 }
 
-void MidiOutCore :: openVirtualPort( std::string portName )
+void MidiOutCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutCore :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiOutCore::setPortName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutCore :: openVirtualPort( const std::string &portName )
 {
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
@@ -994,9 +1379,10 @@ void MidiOutCore :: openVirtualPort( std::string portName )
 
   // Create a virtual MIDI output source.
   MIDIEndpointRef endpoint;
-  OSStatus result = MIDISourceCreate( data->client,
-                                      CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
-                                      &endpoint );
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDISourceCreate( data->client, portNameRef, &endpoint );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     errorString_ = "MidiOutCore::initialize: error creating OS-X virtual MIDI source.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1007,13 +1393,13 @@ void MidiOutCore :: openVirtualPort( std::string portName )
   data->endpoint = endpoint;
 }
 
-void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
 {
   // We use the MIDISendSysex() function to asynchronously send sysex
   // messages.  Otherwise, we use a single CoreMidi MIDIPacket.
-  unsigned int nBytes = message->size();
+  unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes == 0 ) {
-    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";      
+    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
@@ -1022,27 +1408,27 @@ void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
   OSStatus result;
 
-  if ( message->at(0) != 0xF0 && nBytes > 3 ) {
+  if ( message[0] != 0xF0 && nBytes > 3 ) {
     errorString_ = "MidiOutCore::sendMessage: message format problem ... not sysex but > 3 bytes?";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
 
-  Byte buffer[nBytes+(sizeof(MIDIPacketList))];
-  ByteCount listSize = sizeof(buffer);
+  Byte buffer[nBytes+(sizeof( MIDIPacketList ))];
+  ByteCount listSize = sizeof( buffer );
   MIDIPacketList *packetList = (MIDIPacketList*)buffer;
   MIDIPacket *packet = MIDIPacketListInit( packetList );
 
   ByteCount remainingBytes = nBytes;
-  while (remainingBytes && packet) {
+  while ( remainingBytes && packet ) {
     ByteCount bytesForPacket = remainingBytes > 65535 ? 65535 : remainingBytes; // 65535 = maximum size of a MIDIPacket
-    const Byte* dataStartPtr = (const Byte *) &message->at( nBytes - remainingBytes );
-    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr);
-    remainingBytes -= bytesForPacket; 
+    const Byte* dataStartPtr = (const Byte *) &message[nBytes - remainingBytes];
+    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr );
+    remainingBytes -= bytesForPacket;
   }
 
   if ( !packet ) {
-    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";      
+    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -1106,7 +1492,7 @@ struct AlsaMidiData {
   unsigned char *buffer;
   pthread_t thread;
   pthread_t dummy_thread_id;
-  unsigned long long lastTime;
+  snd_seq_real_time_t lastTime;
   int queue_id; // an input queue is needed to get timestamped events
   int trigger_fds[2];
 };
@@ -1124,7 +1510,7 @@ static void *alsaMidiHandler( void *ptr )
   AlsaMidiData *apiData = static_cast<AlsaMidiData *> (data->apiData);
 
   long nBytes;
-  unsigned long long time, lastTime;
+  double time;
   bool continueSysex = false;
   bool doDecode = false;
   MidiInApi::MidiMessage message;
@@ -1223,7 +1609,7 @@ static void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;
 
-		case SND_SEQ_EVENT_SYSEX:
+    case SND_SEQ_EVENT_SYSEX:
       if ( (data->ignoreFlags & 0x01) ) break;
       if ( ev->data.ext.len > apiData->bufferSize ) {
         apiData->bufferSize = ev->data.ext.len;
@@ -1235,6 +1621,8 @@ static void *alsaMidiHandler( void *ptr )
           break;
         }
       }
+      doDecode = true;
+      break;
 
     default:
       doDecode = true;
@@ -1266,14 +1654,37 @@ static void *alsaMidiHandler( void *ptr )
 
           // Method 2: Use the ALSA sequencer event time data.
           // (thanks to Pedro Lopez-Cabanillas!).
-          time = ( ev->time.time.tv_sec * 1000000 ) + ( ev->time.time.tv_nsec/1000 );
-          lastTime = time;
-          time -= apiData->lastTime;
-          apiData->lastTime = lastTime;
+
+          // Using method from:
+          // https://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html
+
+          // Perform the carry for the later subtraction by updating y.
+          // Temp var y is timespec because computation requires signed types,
+          // while snd_seq_real_time_t has unsigned types.
+          snd_seq_real_time_t &x( ev->time.time );
+          struct timespec y;
+          y.tv_nsec = apiData->lastTime.tv_nsec;
+          y.tv_sec = apiData->lastTime.tv_sec;
+          if ( x.tv_nsec < y.tv_nsec ) {
+              int nsec = (y.tv_nsec - (int)x.tv_nsec) / 1000000000 + 1;
+              y.tv_nsec -= 1000000000 * nsec;
+              y.tv_sec += nsec;
+          }
+          if ( x.tv_nsec - y.tv_nsec > 1000000000 ) {
+              int nsec = ((int)x.tv_nsec - y.tv_nsec) / 1000000000;
+              y.tv_nsec += 1000000000 * nsec;
+              y.tv_sec -= nsec;
+          }
+
+          // Compute the time difference.
+          time = (int)x.tv_sec - y.tv_sec + ((int)x.tv_nsec - y.tv_nsec)*1e-9;
+
+          apiData->lastTime = ev->time.time;
+
           if ( data->firstMessage == true )
             data->firstMessage = false;
           else
-            message.timeStamp = time * 0.000001;
+            message.timeStamp = time;
         }
         else {
 #if defined(__RTMIDI_DEBUG__)
@@ -1292,13 +1703,7 @@ static void *alsaMidiHandler( void *ptr )
     }
     else {
       // As long as we haven't reached our queue size limit, push the message.
-      if ( data->queue.size < data->queue.ringSize ) {
-        data->queue.ring[data->queue.back++] = message;
-        if ( data->queue.back == data->queue.ringSize )
-          data->queue.back = 0;
-        data->queue.size++;
-      }
-      else
+      if ( !data->queue.push( message ) )
         std::cerr << "\nMidiInAlsa: message queue limit reached!!\n\n";
     }
   }
@@ -1310,21 +1715,22 @@ static void *alsaMidiHandler( void *ptr )
   return 0;
 }
 
-MidiInAlsa :: MidiInAlsa( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInAlsa :: MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInAlsa::initialize( clientName );
 }
 
 MidiInAlsa :: ~MidiInAlsa()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInAlsa::closePort();
 
   // Shutdown the input thread.
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
     if ( !pthread_equal(data->thread, data->dummy_thread_id) )
       pthread_join( data->thread, NULL );
@@ -1345,7 +1751,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 {
   // Set up the ALSA sequencer client.
   snd_seq_t *seq;
-  int result = snd_seq_open(&seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK);
+  int result = snd_seq_open( &seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK );
   if ( result < 0 ) {
     errorString_ = "MidiInAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1368,7 +1774,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
 
-   if ( pipe(data->trigger_fds) == -1 ) {
+  if ( pipe(data->trigger_fds) == -1 ) {
     errorString_ = "MidiInAlsa::initialize: error creating pipe objects.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -1376,14 +1782,14 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 
   // Create the input queue
 #ifndef AVOID_TIMESTAMPING
-  data->queue_id = snd_seq_alloc_named_queue(seq, "RtMidi Queue");
+  data->queue_id = snd_seq_alloc_named_queue( seq, "RtMidi Queue" );
   // Set arbitrary tempo (mm=100) and resolution (240)
   snd_seq_queue_tempo_t *qtempo;
-  snd_seq_queue_tempo_alloca(&qtempo);
-  snd_seq_queue_tempo_set_tempo(qtempo, 600000);
-  snd_seq_queue_tempo_set_ppq(qtempo, 240);
-  snd_seq_set_queue_tempo(data->seq, data->queue_id, qtempo);
-  snd_seq_drain_output(data->seq);
+  snd_seq_queue_tempo_alloca( &qtempo );
+  snd_seq_queue_tempo_set_tempo( qtempo, 600000 );
+  snd_seq_queue_tempo_set_ppq( qtempo, 240 );
+  snd_seq_set_queue_tempo( data->seq, data->queue_id, qtempo );
+  snd_seq_drain_output( data->seq );
 #endif
 }
 
@@ -1405,7 +1811,9 @@ unsigned int portInfo( snd_seq_t *seq, snd_seq_port_info_t *pinfo, unsigned int 
     while ( snd_seq_query_next_port( seq, pinfo ) >= 0 ) {
       unsigned int atyp = snd_seq_port_info_get_type( pinfo );
       if ( ( ( atyp & SND_SEQ_PORT_TYPE_MIDI_GENERIC ) == 0 ) &&
-        ( ( atyp & SND_SEQ_PORT_TYPE_SYNTH ) == 0 ) ) continue;
+           ( ( atyp & SND_SEQ_PORT_TYPE_SYNTH ) == 0 ) &&
+           ( ( atyp & SND_SEQ_PORT_TYPE_APPLICATION ) == 0 ) ) continue;
+
       unsigned int caps = snd_seq_port_info_get_capability( pinfo );
       if ( ( caps & type ) != type ) continue;
       if ( count == portNumber ) return 1;
@@ -1441,6 +1849,8 @@ std::string MidiInAlsa :: getPortName( unsigned int portNumber )
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
     os << snd_seq_client_info_get_name( cinfo );
+    os << ":";
+    os << snd_seq_port_info_get_name( pinfo );
     os << " ";                                    // These lines added to make sure devices are listed
     os << snd_seq_port_info_get_client( pinfo );  // with full portnames added to ensure individual device names
     os << ":";
@@ -1455,7 +1865,7 @@ std::string MidiInAlsa :: getPortName( unsigned int portNumber )
   return stringName;
 }
 
-void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInAlsa :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiInAlsa::openPort: a valid connection already exists!";
@@ -1499,33 +1909,33 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
                                 SND_SEQ_PORT_TYPE_APPLICATION );
     snd_seq_port_info_set_midi_channels(pinfo, 16);
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo,  portName.c_str() );
-    data->vport = snd_seq_create_port(data->seq, pinfo);
-  
+    snd_seq_port_info_set_name( pinfo,  portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
+
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error creating input port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   receiver.port = data->vport;
 
   if ( !data->subscription ) {
     // Make subscription
-    if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+    if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error allocation port subscription.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-    snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-    if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+    snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+    snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+    if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
       snd_seq_port_subscribe_free( data->subscription );
       data->subscription = 0;
       errorString_ = "MidiInAlsa::openPort: ALSA error making port connection.";
@@ -1542,13 +1952,13 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       snd_seq_unsubscribe_port( data->seq, data->subscription );
       snd_seq_port_subscribe_free( data->subscription );
@@ -1563,38 +1973,38 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
   connected_ = true;
 }
 
-void MidiInAlsa :: openVirtualPort( std::string portName )
+void MidiInAlsa :: openVirtualPort( const std::string &portName )
 {
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     snd_seq_port_info_t *pinfo;
     snd_seq_port_info_alloca( &pinfo );
     snd_seq_port_info_set_capability( pinfo,
-				      SND_SEQ_PORT_CAP_WRITE |
-				      SND_SEQ_PORT_CAP_SUBS_WRITE );
+                                      SND_SEQ_PORT_CAP_WRITE |
+                                      SND_SEQ_PORT_CAP_SUBS_WRITE );
     snd_seq_port_info_set_type( pinfo,
-				SND_SEQ_PORT_TYPE_MIDI_GENERIC |
-				SND_SEQ_PORT_TYPE_APPLICATION );
-    snd_seq_port_info_set_midi_channels(pinfo, 16);
+                                SND_SEQ_PORT_TYPE_MIDI_GENERIC |
+                                SND_SEQ_PORT_TYPE_APPLICATION );
+    snd_seq_port_info_set_midi_channels( pinfo, 16 );
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo, portName.c_str());
-    data->vport = snd_seq_create_port(data->seq, pinfo);
+    snd_seq_port_info_set_name( pinfo, portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
 
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openVirtualPort: ALSA error creating virtual port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   if ( inputData_.doInput == false ) {
     // Wait for old thread to stop, if still running
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
 
     // Start the input queue
@@ -1604,13 +2014,13 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       if ( data->subscription ) {
         snd_seq_unsubscribe_port( data->seq, data->subscription );
@@ -1646,11 +2056,29 @@ void MidiInAlsa :: closePort( void )
   // Stop thread to avoid triggering the callback, while the port is intended to be closed
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
   }
+}
+
+void MidiInAlsa :: setClientName( const std::string &clientName )
+{
+
+  AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+  snd_seq_set_client_name( data->seq, clientName.c_str() );
+
+}
+
+void MidiInAlsa :: setPortName( const std::string &portName )
+{
+  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
+  snd_seq_get_port_info( data->seq, data->vport, pinfo );
+  snd_seq_port_info_set_name( pinfo, portName.c_str() );
+  snd_seq_set_port_info( data->seq, data->vport, pinfo );
 }
 
 //*********************************************************************//
@@ -1658,15 +2086,15 @@ void MidiInAlsa :: closePort( void )
 //  Class Definitions: MidiOutAlsa
 //*********************************************************************//
 
-MidiOutAlsa :: MidiOutAlsa( const std::string clientName ) : MidiOutApi()
+MidiOutAlsa :: MidiOutAlsa( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutAlsa::initialize( clientName );
 }
 
 MidiOutAlsa :: ~MidiOutAlsa()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutAlsa::closePort();
 
   // Cleanup.
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
@@ -1686,7 +2114,7 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
     errorString_ = "MidiOutAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
-	}
+  }
 
   // Set client name.
   snd_seq_set_client_name( seq, clientName.c_str() );
@@ -1719,8 +2147,8 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
 
 unsigned int MidiOutAlsa :: getPortCount()
 {
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
 
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   return portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, -1 );
@@ -1736,14 +2164,16 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
   std::string stringName;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) ) {
-    int cnum = snd_seq_port_info_get_client(pinfo);
+    int cnum = snd_seq_port_info_get_client( pinfo );
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
-    os << snd_seq_client_info_get_name(cinfo);
+    os << snd_seq_client_info_get_name( cinfo );
+    os << ":";
+    os << snd_seq_port_info_get_name( pinfo );
     os << " ";                                    // These lines added to make sure devices are listed
     os << snd_seq_port_info_get_client( pinfo );  // with full portnames added to ensure individual device names
     os << ":";
-    os << snd_seq_port_info_get_port(pinfo);
+    os << snd_seq_port_info_get_port( pinfo );
     stringName = os.str();
     return stringName;
   }
@@ -1754,7 +2184,7 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
   return stringName;
 }
 
-void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutAlsa::openPort: a valid connection already exists!";
@@ -1763,14 +2193,14 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
   }
 
   unsigned int nSrc = this->getPortCount();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiOutAlsa::openPort: no MIDI output sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
   }
 
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) == 0 ) {
     std::ostringstream ost;
@@ -1799,17 +2229,17 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
   sender.port = data->vport;
 
   // Make subscription
-  if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+  if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: error allocating port subscription.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
-  snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-  snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-  snd_seq_port_subscribe_set_time_update(data->subscription, 1);
-  snd_seq_port_subscribe_set_time_real(data->subscription, 1);
-  if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+  snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+  snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+  snd_seq_port_subscribe_set_time_update( data->subscription, 1 );
+  snd_seq_port_subscribe_set_time_real( data->subscription, 1 );
+  if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: ALSA error making port connection.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1825,11 +2255,30 @@ void MidiOutAlsa :: closePort( void )
     AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
     snd_seq_unsubscribe_port( data->seq, data->subscription );
     snd_seq_port_subscribe_free( data->subscription );
+    data->subscription = 0;
     connected_ = false;
   }
 }
 
-void MidiOutAlsa :: openVirtualPort( std::string portName )
+void MidiOutAlsa :: setClientName( const std::string &clientName )
+{
+
+    AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+    snd_seq_set_client_name( data->seq, clientName.c_str() );
+
+}
+
+void MidiOutAlsa :: setPortName( const std::string &portName )
+{
+  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
+  snd_seq_get_port_info( data->seq, data->vport, pinfo );
+  snd_seq_port_info_set_name( pinfo, portName.c_str() );
+  snd_seq_set_port_info( data->seq, data->vport, pinfo );
+}
+
+void MidiOutAlsa :: openVirtualPort( const std::string &portName )
 {
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
@@ -1844,14 +2293,14 @@ void MidiOutAlsa :: openVirtualPort( std::string portName )
   }
 }
 
-void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
 {
   int result;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
-  unsigned int nBytes = message->size();
+  unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes > data->bufferSize ) {
     data->bufferSize = nBytes;
-    result = snd_midi_event_resize_buffer ( data->coder, nBytes);
+    result = snd_midi_event_resize_buffer( data->coder, nBytes );
     if ( result != 0 ) {
       errorString_ = "MidiOutAlsa::sendMessage: ALSA error resizing MIDI event buffer.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1860,18 +2309,18 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
     free (data->buffer);
     data->buffer = (unsigned char *) malloc( data->bufferSize );
     if ( data->buffer == NULL ) {
-    errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
-    error( RtMidiError::MEMORY_ERROR, errorString_ );
-    return;
+      errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
+      error( RtMidiError::MEMORY_ERROR, errorString_ );
+      return;
     }
   }
 
   snd_seq_event_t ev;
-  snd_seq_ev_clear(&ev);
-  snd_seq_ev_set_source(&ev, data->vport);
-  snd_seq_ev_set_subs(&ev);
-  snd_seq_ev_set_direct(&ev);
-  for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message->at(i);
+  snd_seq_ev_clear( &ev );
+  snd_seq_ev_set_source( &ev, data->vport );
+  snd_seq_ev_set_subs( &ev );
+  snd_seq_ev_set_direct( &ev );
+  for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message[i];
   result = snd_midi_event_encode( data->coder, data->buffer, (long)nBytes, &ev );
   if ( result < (int)nBytes ) {
     errorString_ = "MidiOutAlsa::sendMessage: event parsing error!";
@@ -1880,13 +2329,13 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
   }
 
   // Send the event.
-  result = snd_seq_event_output(data->seq, &ev);
+  result = snd_seq_event_output( data->seq, &ev );
   if ( result < 0 ) {
     errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
-  snd_seq_drain_output(data->seq);
+  snd_seq_drain_output( data->seq );
 }
 
 #endif // __LINUX_ALSA__
@@ -1911,6 +2360,34 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
 #include <windows.h>
 #include <mmsystem.h>
 
+// Convert a null-terminated wide string or ANSI-encoded string to UTF-8.
+static std::string ConvertToUTF8(const TCHAR *str)
+{
+  std::string u8str;
+  const WCHAR *wstr = L"";
+#if defined( UNICODE ) || defined( _UNICODE )
+  wstr = str;
+#else
+  // Convert from ANSI encoding to wide string
+  int wlength = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
+  std::wstring wstrtemp;
+  if ( wlength )
+  {
+    wstrtemp.assign( wlength - 1, 0 );
+    MultiByteToWideChar( CP_ACP, 0, str, -1, &wstrtemp[0], wlength );
+    wstr = &wstrtemp[0];
+  }
+#endif
+  // Convert from wide string to UTF-8
+  int length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
+  if ( length )
+  {
+    u8str.assign( length - 1, 0 );
+    length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, &u8str[0], length, NULL, NULL );
+  }
+  return u8str;
+}
+
 #define  RT_SYSEX_BUFFER_SIZE 1024
 #define  RT_SYSEX_BUFFER_COUNT 4
 
@@ -1931,7 +2408,7 @@ struct WinMidiData {
 //*********************************************************************//
 
 static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
-                                        UINT inputStatus, 
+                                        UINT inputStatus,
                                         DWORD_PTR instancePtr,
                                         DWORD_PTR midiMessage,
                                         DWORD timestamp )
@@ -1948,7 +2425,6 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     data->firstMessage = false;
   }
   else apiData->message.timeStamp = (double) ( timestamp - apiData->lastTime ) * 0.001;
-  apiData->lastTime = timestamp;
 
   if ( inputStatus == MIM_DATA ) { // Channel or system message
 
@@ -1967,11 +2443,11 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     }
     else if ( status == 0xF2 ) nBytes = 3;
     else if ( status == 0xF3 ) nBytes = 2;
-    else if ( status == 0xF8 && (data->ignoreFlags & 0x02) ) {
+    else if ( status == 0xF8 && ( data->ignoreFlags & 0x02 ) ) {
       // A MIDI timing tick message and we're ignoring it.
       return;
     }
-    else if ( status == 0xFE && (data->ignoreFlags & 0x04) ) {
+    else if ( status == 0xFE && ( data->ignoreFlags & 0x04 ) ) {
       // A MIDI active sensing message and we're ignoring it.
       return;
     }
@@ -1981,8 +2457,8 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     for ( int i=0; i<nBytes; ++i ) apiData->message.bytes.push_back( *ptr++ );
   }
   else { // Sysex message ( MIM_LONGDATA or MIM_LONGERROR )
-    MIDIHDR *sysex = ( MIDIHDR *) midiMessage; 
-    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {  
+    MIDIHDR *sysex = ( MIDIHDR *) midiMessage;
+    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {
       // Sysex message and we're not ignoring it
       for ( int i=0; i<(int)sysex->dwBytesRecorded; ++i )
         apiData->message.bytes.push_back( sysex->lpData[i] );
@@ -2009,35 +2485,33 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     else return;
   }
 
+  // Save the time of the last non-filtered message
+  apiData->lastTime = timestamp;
+
   if ( data->usingCallback ) {
     RtMidiIn::RtMidiCallback callback = (RtMidiIn::RtMidiCallback) data->userCallback;
     callback( apiData->message.timeStamp, &apiData->message.bytes, data->userData );
   }
   else {
     // As long as we haven't reached our queue size limit, push the message.
-    if ( data->queue.size < data->queue.ringSize ) {
-      data->queue.ring[data->queue.back++] = apiData->message;
-      if ( data->queue.back == data->queue.ringSize )
-        data->queue.back = 0;
-      data->queue.size++;
-    }
-    else
-      std::cerr << "\nRtMidiIn: message queue limit reached!!\n\n";
+    if ( !data->queue.push( apiData->message ) )
+      std::cerr << "\nMidiInWinMM: message queue limit reached!!\n\n";
   }
 
   // Clear the vector for the next input message.
   apiData->message.bytes.clear();
 }
 
-MidiInWinMM :: MidiInWinMM( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInWinMM :: MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInWinMM::initialize( clientName );
 }
 
 MidiInWinMM :: ~MidiInWinMM()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInWinMM::closePort();
 
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
   DeleteCriticalSection( &(data->_mutex) );
@@ -2062,13 +2536,13 @@ void MidiInWinMM :: initialize( const std::string& /*clientName*/ )
   inputData_.apiData = (void *) data;
   data->message.bytes.clear();  // needs to be empty for first input message
 
-  if ( !InitializeCriticalSectionAndSpinCount(&(data->_mutex), 0x00000400) ) {
+  if ( !InitializeCriticalSectionAndSpinCount( &(data->_mutex), 0x00000400 ) ) {
     errorString_ = "MidiInWinMM::initialize: InitializeCriticalSectionAndSpinCount failed.";
     error( RtMidiError::WARNING, errorString_ );
   }
 }
 
-void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portName*/ )
+void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*portName*/ )
 {
   if ( connected_ ) {
     errorString_ = "MidiInWinMM::openPort: a valid connection already exists!";
@@ -2114,6 +2588,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInPrepareHeader( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (PrepareHeader).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2123,6 +2598,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInAddBuffer( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (AddBuffer).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2132,6 +2608,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
   result = midiInStart( data->inHandle );
   if ( result != MMSYSERR_NOERROR ) {
     midiInClose( data->inHandle );
+    data->inHandle = 0;
     errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2140,7 +2617,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
   connected_ = true;
 }
 
-void MidiInWinMM :: openVirtualPort( std::string /*portName*/ )
+void MidiInWinMM :: openVirtualPort( const std::string &/*portName*/ )
 {
   // This function cannot be implemented for the Windows MM MIDI API.
   errorString_ = "MidiInWinMM::openVirtualPort: cannot be implemented in Windows MM MIDI API!";
@@ -2161,6 +2638,7 @@ void MidiInWinMM :: closePort( void )
       delete [] data->sysexBuffer[i];
       if ( result != MMSYSERR_NOERROR ) {
         midiInClose( data->inHandle );
+        data->inHandle = 0;
         errorString_ = "MidiInWinMM::openPort: error closing Windows MM MIDI input port (midiInUnprepareHeader).";
         error( RtMidiError::DRIVER_ERROR, errorString_ );
         return;
@@ -2168,9 +2646,26 @@ void MidiInWinMM :: closePort( void )
     }
 
     midiInClose( data->inHandle );
+    data->inHandle = 0;
     connected_ = false;
     LeaveCriticalSection( &(data->_mutex) );
   }
+}
+
+void MidiInWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInWinMM :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiInWinMM::setPortName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 unsigned int MidiInWinMM :: getPortCount()
@@ -2192,22 +2687,17 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 
   MIDIINCAPS deviceCaps;
   midiInGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIINCAPS));
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
-
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
+#ifndef RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
   std::ostringstream os;
   os << " ";
   os << portNumber;
   stringName += os.str();
+#endif
 
   return stringName;
 }
@@ -2217,15 +2707,15 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 //  Class Definitions: MidiOutWinMM
 //*********************************************************************//
 
-MidiOutWinMM :: MidiOutWinMM( const std::string clientName ) : MidiOutApi()
+MidiOutWinMM :: MidiOutWinMM( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutWinMM::initialize( clientName );
 }
 
 MidiOutWinMM :: ~MidiOutWinMM()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutWinMM::closePort();
 
   // Cleanup.
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
@@ -2265,28 +2755,23 @@ std::string MidiOutWinMM :: getPortName( unsigned int portNumber )
   }
 
   MIDIOUTCAPS deviceCaps;
-  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIOUTCAPS));
+  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof( MIDIOUTCAPS ) );
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
-
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
   std::ostringstream os;
+#ifndef RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
   os << " ";
   os << portNumber;
   stringName += os.str();
+#endif
 
   return stringName;
 }
 
-void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string /*portName*/ )
+void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string &/*portName*/ )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutWinMM::openPort: a valid connection already exists!";
@@ -2295,7 +2780,7 @@ void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string /*port
   }
 
   unsigned int nDevices = midiOutGetNumDevs();
-  if (nDevices < 1) {
+  if ( nDevices < 1 ) {
     errorString_ = "MidiOutWinMM::openPort: no MIDI output destinations found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -2330,22 +2815,39 @@ void MidiOutWinMM :: closePort( void )
     WinMidiData *data = static_cast<WinMidiData *> (apiData_);
     midiOutReset( data->outHandle );
     midiOutClose( data->outHandle );
+    data->outHandle = 0;
     connected_ = false;
   }
 }
 
-void MidiOutWinMM :: openVirtualPort( std::string /*portName*/ )
+void MidiOutWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutWinMM :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiOutWinMM::setPortName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutWinMM :: openVirtualPort( const std::string &/*portName*/ )
 {
   // This function cannot be implemented for the Windows MM MIDI API.
   errorString_ = "MidiOutWinMM::openVirtualPort: cannot be implemented in Windows MM MIDI API!";
   error( RtMidiError::WARNING, errorString_ );
 }
 
-void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
 {
   if ( !connected_ ) return;
 
-  unsigned int nBytes = static_cast<unsigned int>(message->size());
+  unsigned int nBytes = static_cast<unsigned int>(size);
   if ( nBytes == 0 ) {
     errorString_ = "MidiOutWinMM::sendMessage: message argument is empty!";
     error( RtMidiError::WARNING, errorString_ );
@@ -2354,7 +2856,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
 
   MMRESULT result;
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-  if ( message->at(0) == 0xF0 ) { // Sysex message
+  if ( message[0] == 0xF0 ) { // Sysex message
 
     // Allocate buffer for sysex data.
     char *buffer = (char *) malloc( nBytes );
@@ -2365,14 +2867,14 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Copy data to buffer.
-    for ( unsigned int i=0; i<nBytes; ++i ) buffer[i] = message->at(i);
+    for ( unsigned int i=0; i<nBytes; ++i ) buffer[i] = message[i];
 
     // Create and prepare MIDIHDR structure.
     MIDIHDR sysex;
     sysex.lpData = (LPSTR) buffer;
     sysex.dwBufferLength = nBytes;
     sysex.dwFlags = 0;
-    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof(MIDIHDR) ); 
+    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error preparing sysex header.";
@@ -2381,7 +2883,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Send the message.
-    result = midiOutLongMsg( data->outHandle, &sysex, sizeof(MIDIHDR) );
+    result = midiOutLongMsg( data->outHandle, &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error sending sysex message.";
@@ -2390,7 +2892,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Unprepare the buffer and MIDIHDR.
-    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof (MIDIHDR) ) ) Sleep( 1 );
+    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof ( MIDIHDR ) ) ) Sleep( 1 );
     free( buffer );
   }
   else { // Channel or system message.
@@ -2406,7 +2908,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     DWORD packet;
     unsigned char *ptr = (unsigned char *) &packet;
     for ( unsigned int i=0; i<nBytes; ++i ) {
-      *ptr = message->at(i);
+      *ptr = message[i];
       ++ptr;
     }
 
@@ -2436,6 +2938,9 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
 #include <jack/jack.h>
 #include <jack/midiport.h>
 #include <jack/ringbuffer.h>
+#ifdef HAVE_SEMAPHORE
+  #include <semaphore.h>
+#endif
 
 #define JACK_RINGBUFFER_SIZE 16384 // Default size for ringbuffer
 
@@ -2445,6 +2950,10 @@ struct JackMidiData {
   jack_ringbuffer_t *buffSize;
   jack_ringbuffer_t *buffMessage;
   jack_time_t lastTime;
+#ifdef HAVE_SEMAPHORE
+  sem_t sem_cleanup;
+  sem_t sem_needpost;
+#endif
   MidiInApi :: RtMidiInData *rtMidiIn;
   };
 
@@ -2462,42 +2971,71 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
 
   // Is port created?
   if ( jData->port == NULL ) return 0;
+
   void *buff = jack_port_get_buffer( jData->port, nframes );
+  bool& continueSysex = rtData->continueSysex;
+  unsigned char& ignoreFlags = rtData->ignoreFlags;
 
   // We have midi events in buffer
   int evCount = jack_midi_get_event_count( buff );
   for (int j = 0; j < evCount; j++) {
-    MidiInApi::MidiMessage message;
-    message.bytes.clear();
-
+    MidiInApi::MidiMessage& message = rtData->message;
     jack_midi_event_get( &event, buff, j );
-
-    for ( unsigned int i = 0; i < event.size; i++ )
-      message.bytes.push_back( event.buffer[i] );
 
     // Compute the delta time.
     time = jack_get_time();
-    if ( rtData->firstMessage == true )
+    if ( rtData->firstMessage == true ) {
+      message.timeStamp = 0.0;
       rtData->firstMessage = false;
-    else
+    } else
       message.timeStamp = ( time - jData->lastTime ) * 0.000001;
 
     jData->lastTime = time;
 
-    if ( !rtData->continueSysex ) {
+    if ( !continueSysex )
+      message.bytes.clear();
+
+    if ( !( ( continueSysex || event.buffer[0] == 0xF0 ) && ( ignoreFlags & 0x01 ) ) ) {
+      // Unless this is a (possibly continued) SysEx message and we're ignoring SysEx,
+      // copy the event buffer into the MIDI message struct.
+      for ( unsigned int i = 0; i < event.size; i++ )
+        message.bytes.push_back( event.buffer[i] );
+    }
+
+    switch ( event.buffer[0] ) {
+      case 0xF0:
+        // Start of a SysEx message
+        continueSysex = event.buffer[event.size - 1] != 0xF7;
+        if ( ignoreFlags & 0x01 ) continue;
+        break;
+      case 0xF1:
+      case 0xF8:
+        // MIDI Time Code or Timing Clock message
+        if ( ignoreFlags & 0x02 ) continue;
+        break;
+      case 0xFE:
+        // Active Sensing message
+        if ( ignoreFlags & 0x04 ) continue;
+        break;
+      default:
+        if ( continueSysex ) {
+          // Continuation of a SysEx message
+          continueSysex = event.buffer[event.size - 1] != 0xF7;
+          if ( ignoreFlags & 0x01 ) continue;
+        }
+        // All other MIDI messages
+    }
+
+    if ( !continueSysex ) {
+      // If not a continuation of a SysEx message,
+      // invoke the user callback function or queue the message.
       if ( rtData->usingCallback ) {
         RtMidiIn::RtMidiCallback callback = (RtMidiIn::RtMidiCallback) rtData->userCallback;
         callback( message.timeStamp, &message.bytes, rtData->userData );
       }
       else {
         // As long as we haven't reached our queue size limit, push the message.
-        if ( rtData->queue.size < rtData->queue.ringSize ) {
-          rtData->queue.ring[rtData->queue.back++] = message;
-          if ( rtData->queue.back == rtData->queue.ringSize )
-            rtData->queue.back = 0;
-          rtData->queue.size++;
-        }
-        else
+        if ( !rtData->queue.push( message ) )
           std::cerr << "\nMidiInJack: message queue limit reached!!\n\n";
       }
     }
@@ -2506,9 +3044,10 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
   return 0;
 }
 
-MidiInJack :: MidiInJack( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInJack :: MidiInJack( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInJack::initialize( clientName );
 }
 
 void MidiInJack :: initialize( const std::string& clientName )
@@ -2544,25 +3083,25 @@ void MidiInJack :: connect()
 MidiInJack :: ~MidiInJack()
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  closePort();
+  MidiInJack::closePort();
 
   if ( data->client )
     jack_client_close( data->client );
   delete data;
 }
 
-void MidiInJack :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInJack :: openPort( unsigned int portNumber, const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   connect();
 
   // Creating new port
-  if ( data->port == NULL)
+  if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
                                      JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0 );
 
-  if ( data->port == NULL) {
+  if ( data->port == NULL ) {
     errorString_ = "MidiInJack::openPort: JACK error creating port";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2571,9 +3110,11 @@ void MidiInJack :: openPort( unsigned int portNumber, const std::string portName
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, name.c_str(), jack_port_name( data->port ) );
+
+  connected_ = true;
 }
 
-void MidiInJack :: openVirtualPort( const std::string portName )
+void MidiInJack :: openVirtualPort( const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
@@ -2611,7 +3152,7 @@ unsigned int MidiInJack :: getPortCount()
 std::string MidiInJack :: getPortName( unsigned int portNumber )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  std::string retStr("");
+  std::string retStr( "" );
 
   connect();
 
@@ -2626,7 +3167,9 @@ std::string MidiInJack :: getPortName( unsigned int portNumber )
     return retStr;
   }
 
-  if ( ports[portNumber] == NULL ) {
+  unsigned int i;
+  for ( i=0; i<portNumber && ports[i]; i++ ) {}
+  if ( i < portNumber || !ports[portNumber] ) {
     std::ostringstream ost;
     ost << "MidiInJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -2634,7 +3177,7 @@ std::string MidiInJack :: getPortName( unsigned int portNumber )
   }
   else retStr.assign( ports[portNumber] );
 
-  free( ports );
+  jack_free( ports );
   return retStr;
 }
 
@@ -2645,6 +3188,26 @@ void MidiInJack :: closePort()
   if ( data->port == NULL ) return;
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
+}
+
+void MidiInJack:: setClientName( const std::string& )
+{
+
+  errorString_ = "MidiInJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInJack :: setPortName( const std::string &portName )
+{
+  JackMidiData *data = static_cast<JackMidiData *> (apiData_);
+#ifdef JACK_HAS_PORT_RENAME
+  jack_port_rename( data->client, data->port, portName.c_str() );
+#else
+  jack_port_set_name( data->port, portName.c_str() );
+#endif
 }
 
 //*********************************************************************//
@@ -2666,18 +3229,23 @@ static int jackProcessOut( jack_nframes_t nframes, void *arg )
   jack_midi_clear_buffer( buff );
 
   while ( jack_ringbuffer_read_space( data->buffSize ) > 0 ) {
-    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof(space) );
+    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof( space ) );
     midiData = jack_midi_event_reserve( buff, 0, space );
 
     jack_ringbuffer_read( data->buffMessage, (char *) midiData, (size_t) space );
   }
 
+#ifdef HAVE_SEMAPHORE
+  if ( !sem_trywait( &data->sem_needpost ) )
+    sem_post( &data->sem_cleanup );
+#endif
+
   return 0;
 }
 
-MidiOutJack :: MidiOutJack( const std::string clientName ) : MidiOutApi()
+MidiOutJack :: MidiOutJack( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutJack::initialize( clientName );
 }
 
 void MidiOutJack :: initialize( const std::string& clientName )
@@ -2687,6 +3255,10 @@ void MidiOutJack :: initialize( const std::string& clientName )
 
   data->port = NULL;
   data->client = NULL;
+#ifdef HAVE_SEMAPHORE
+  sem_init( &data->sem_cleanup, 0, 0 );
+  sem_init( &data->sem_needpost, 0, 0 );
+#endif
   this->clientName = clientName;
 
   connect();
@@ -2697,13 +3269,13 @@ void MidiOutJack :: connect()
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
   if ( data->client )
     return;
-  
-  // Initialize output ringbuffers  
+
+  // Initialize output ringbuffers
   data->buffSize = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
   data->buffMessage = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
 
   // Initialize JACK client
-  if (( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL )) == 0) {
+  if ( ( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL ) ) == 0 ) {
     errorString_ = "MidiOutJack::initialize: JACK server not running?";
     error( RtMidiError::WARNING, errorString_ );
     return;
@@ -2716,8 +3288,8 @@ void MidiOutJack :: connect()
 MidiOutJack :: ~MidiOutJack()
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  closePort();
-  
+  MidiOutJack::closePort();
+
   // Cleanup
   jack_ringbuffer_free( data->buffSize );
   jack_ringbuffer_free( data->buffMessage );
@@ -2725,10 +3297,15 @@ MidiOutJack :: ~MidiOutJack()
     jack_client_close( data->client );
   }
 
+#ifdef HAVE_SEMAPHORE
+  sem_destroy( &data->sem_cleanup );
+  sem_destroy( &data->sem_needpost );
+#endif
+
   delete data;
 }
 
-void MidiOutJack :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutJack :: openPort( unsigned int portNumber, const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
@@ -2737,7 +3314,7 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string portNam
   // Creating new port
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openPort: JACK error creating port";
@@ -2748,16 +3325,18 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string portNam
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, jack_port_name( data->port ), name.c_str() );
+
+  connected_ = true;
 }
 
-void MidiOutJack :: openVirtualPort( const std::string portName )
+void MidiOutJack :: openVirtualPort( const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   connect();
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openVirtualPort: JACK error creating virtual port";
@@ -2775,7 +3354,7 @@ unsigned int MidiOutJack :: getPortCount()
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   if ( ports == NULL ) return 0;
   while ( ports[count] != NULL )
@@ -2795,16 +3374,16 @@ std::string MidiOutJack :: getPortName( unsigned int portNumber )
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   // Check port validity
-  if ( ports == NULL) {
+  if ( ports == NULL ) {
     errorString_ = "MidiOutJack::getPortName: no ports available!";
     error( RtMidiError::WARNING, errorString_ );
     return retStr;
   }
 
-  if ( ports[portNumber] == NULL) {
+  if ( ports[portNumber] == NULL ) {
     std::ostringstream ost;
     ost << "MidiOutJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -2821,18 +3400,47 @@ void MidiOutJack :: closePort()
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   if ( data->port == NULL ) return;
+
+#ifdef HAVE_SEMAPHORE
+  struct timespec ts;
+  if ( clock_gettime( CLOCK_REALTIME, &ts ) != -1 ) {
+    ts.tv_sec += 1; // wait max one second
+    sem_post( &data->sem_needpost );
+    sem_timedwait( &data->sem_cleanup, &ts );
+  }
+#endif
+
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
 }
 
-void MidiOutJack :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutJack:: setClientName( const std::string& )
 {
-  int nBytes = message->size();
+
+  errorString_ = "MidiOutJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutJack :: setPortName( const std::string &portName )
+{
+  JackMidiData *data = static_cast<JackMidiData *> (apiData_);
+#ifdef JACK_HAS_PORT_RENAME
+  jack_port_rename( data->client, data->port, portName.c_str() );
+#else
+  jack_port_set_name( data->port, portName.c_str() );
+#endif
+}
+
+void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )
+{
+  int nBytes = static_cast<int>(size);
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   // Write full message to buffer
-  jack_ringbuffer_write( data->buffMessage, ( const char * ) &( *message )[0],
-                         message->size() );
+  jack_ringbuffer_write( data->buffMessage, ( const char * ) message, nBytes );
   jack_ringbuffer_write( data->buffSize, ( char * ) &nBytes, sizeof( nBytes ) );
 }
 

--- a/src/RtMidi/RtMidi.h
+++ b/src/RtMidi/RtMidi.h
@@ -5,10 +5,11 @@
     This class implements some common functionality for the realtime
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
-    RtMidi WWW site: http://music.mcgill.ca/~gary/rtmidi/
+    RtMidi GitHub site: https://github.com/thestk/rtmidi
+    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
-    Copyright (c) 2003-2016 Gary P. Scavone
+    Copyright (c) 2003-2019 Gary P. Scavone
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation files
@@ -43,28 +44,21 @@
 #ifndef RTMIDI_H
 #define RTMIDI_H
 
-#define RTMIDI_VERSION "2.1.1"
-
-
-#include <QtGlobal>  // used for OS macros:
-
-#if defined(Q_OS_LINUX)
-    #ifndef __LINUX_ALSA__
-    #define __LINUX_ALSA__
-    #endif
+#if defined _WIN32 || defined __CYGWIN__
+  #if defined(RTMIDI_EXPORT)
+    #define RTMIDI_DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define RTMIDI_DLL_PUBLIC __attribute__( (visibility( "default" )) )
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
 #endif
 
-#if defined(Q_OS_OSX)
-	#ifndef __MACOSX_CORE__
-	#define __MACOSX_CORE__
-	#endif
-#endif
-
-#if defined(Q_OS_WIN)
-	#ifndef __WINDOWS_MM__
-	#define __WINDOWS_MM__
-	#endif
-#endif
+#define RTMIDI_VERSION "4.0.0"
 
 #include <exception>
 #include <iostream>
@@ -81,7 +75,7 @@
 */
 /************************************************************************/
 
-class RtMidiError : public std::exception
+class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
 {
  public:
   //! Defined RtMidiError types.
@@ -100,8 +94,9 @@ class RtMidiError : public std::exception
   };
 
   //! The constructor.
-  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw() : message_(message), type_(type) {}
- 
+  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw()
+    : message_(message), type_(type) {}
+
   //! The destructor.
   virtual ~RtMidiError( void ) throw() {}
 
@@ -109,10 +104,10 @@ class RtMidiError : public std::exception
   virtual void printMessage( void ) const throw() { std::cerr << '\n' << message_ << "\n\n"; }
 
   //! Returns the thrown error message type.
-  virtual const Type& getType(void) const throw() { return type_; }
+  virtual const Type& getType( void ) const throw() { return type_; }
 
   //! Returns the thrown error message string.
-  virtual const std::string& getMessage(void) const throw() { return message_; }
+  virtual const std::string& getMessage( void ) const throw() { return message_; }
 
   //! Returns the thrown error message as a c-style string.
   virtual const char* what( void ) const throw() { return message_.c_str(); }
@@ -134,18 +129,18 @@ typedef void (*RtMidiErrorCallback)( RtMidiError::Type type, const std::string &
 
 class MidiApi;
 
-class RtMidi
+class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
-
   //! MIDI API specifier arguments.
   enum Api {
     UNSPECIFIED,    /*!< Search for a working compiled API. */
-    MACOSX_CORE,    /*!< Macintosh OS-X Core Midi API. */
+    MACOSX_CORE,    /*!< Macintosh OS-X CoreMIDI API. */
     LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     UNIX_JACK,      /*!< The JACK Low-Latency MIDI Server API. */
     WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
+    RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    NUM_APIS        /*!< Number of values in this enum. */
   };
 
   //! A static function to determine the current RtMidi version.
@@ -159,11 +154,34 @@ class RtMidi
   */
   static void getCompiledApi( std::vector<RtMidi::Api> &apis ) throw();
 
+  //! Return the name of a specified compiled MIDI API.
+  /*!
+    This obtains a short lower-case name used for identification purposes.
+    This value is guaranteed to remain identical across library versions.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiName( RtMidi::Api api );
+
+  //! Return the display name of a specified compiled MIDI API.
+  /*!
+    This obtains a long name used for display purposes.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiDisplayName( RtMidi::Api api );
+
+  //! Return the compiled MIDI API having the given name.
+  /*!
+    A case insensitive comparison will check the specified name
+    against the list of compiled APIs, and return the one which
+    matches. On failure, the function returns UNSPECIFIED.
+  */
+  static RtMidi::Api getCompiledApiByName( const std::string &name );
+
   //! Pure virtual openPort() function.
-  virtual void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi" ) ) = 0;
+  virtual void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi" ) ) = 0;
 
   //! Pure virtual openVirtualPort() function.
-  virtual void openVirtualPort( const std::string portName = std::string( "RtMidi" ) ) = 0;
+  virtual void openVirtualPort( const std::string &portName = std::string( "RtMidi" ) ) = 0;
 
   //! Pure virtual getPortCount() function.
   virtual unsigned int getPortCount() = 0;
@@ -174,7 +192,14 @@ class RtMidi
   //! Pure virtual closePort() function.
   virtual void closePort( void ) = 0;
 
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen( void ) const = 0;
 
   //! Set an error callback function to be invoked when an error has occured.
@@ -185,10 +210,8 @@ class RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 ) = 0;
 
  protected:
-
   RtMidi();
   virtual ~RtMidi();
-
   MidiApi *rtapi_;
 };
 
@@ -206,7 +229,7 @@ class RtMidi
     possible to open a virtual input port to which other MIDI software
     clients can connect.
 
-    by Gary P. Scavone, 2003-2014.
+    by Gary P. Scavone, 2003-2017.
 */
 /**********************************************************************/
 
@@ -224,12 +247,12 @@ class RtMidi
 //
 // **************************************************************** //
 
-class RtMidiIn : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 {
  public:
 
   //! User callback function type definition.
-  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData);
+  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData );
 
   //! Default constructor that allows an optional api, client name and queue size.
   /*!
@@ -250,7 +273,7 @@ class RtMidiIn : public RtMidi
     \param queueSizeLimit An optional size of the MIDI input queue can be specified.
   */
   RtMidiIn( RtMidi::Api api=UNSPECIFIED,
-            const std::string clientName = std::string( "RtMidi Input Client"),
+            const std::string& clientName = "RtMidi Input Client",
             unsigned int queueSizeLimit = 100 );
 
   //! If a MIDI connection is still open, it will be closed by the destructor.
@@ -265,7 +288,7 @@ class RtMidiIn : public RtMidi
                       Otherwise, the default or first port found is opened.
     \param portName An optional name for the application port that is used to connect to portId can be specified.
   */
-  void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi Input" ) );
+  void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi Input" ) );
 
   //! Create a virtual input port, with optional name, to allow software connections (OS X, JACK and ALSA only).
   /*!
@@ -277,7 +300,7 @@ class RtMidiIn : public RtMidi
     \param portName An optional name for the application port that is
                     used to connect to portId can be specified.
   */
-  void openVirtualPort( const std::string portName = std::string( "RtMidi Input" ) );
+  void openVirtualPort( const std::string &portName = std::string( "RtMidi Input" ) );
 
   //! Set a callback function to be invoked for incoming MIDI messages.
   /*!
@@ -303,6 +326,10 @@ class RtMidiIn : public RtMidi
   void closePort( void );
 
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen() const;
 
   //! Return the number of available MIDI input ports.
@@ -314,7 +341,8 @@ class RtMidiIn : public RtMidi
   //! Return a string identifier for the specified MIDI input port number.
   /*!
     \return The name of the port with the given Id is returned.
-    \retval An empty string is returned if an invalid port specifier is provided.
+    \retval An empty string is returned if an invalid port specifier
+            is provided. User code should assume a UTF-8 encoding.
   */
   std::string getPortName( unsigned int portNumber = 0 );
 
@@ -346,8 +374,7 @@ class RtMidiIn : public RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );
 
  protected:
-  void openMidiApi( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit );
-
+  void openMidiApi( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit );
 };
 
 /**********************************************************************/
@@ -362,14 +389,13 @@ class RtMidiIn : public RtMidi
     OS-X, Linux ALSA and JACK MIDI APIs, it is also possible to open a
     virtual port to which other MIDI software clients can connect.
 
-    by Gary P. Scavone, 2003-2014.
+    by Gary P. Scavone, 2003-2017.
 */
 /**********************************************************************/
 
-class RtMidiOut : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 {
  public:
-
   //! Default constructor that allows an optional client name.
   /*!
     An exception will be thrown if a MIDI system initialization error occurs.
@@ -379,7 +405,7 @@ class RtMidiOut : public RtMidi
     JACK (OS-X).
   */
   RtMidiOut( RtMidi::Api api=UNSPECIFIED,
-             const std::string clientName = std::string( "RtMidi Output Client") );
+             const std::string& clientName = "RtMidi Output Client" );
 
   //! The destructor closes any open MIDI connections.
   ~RtMidiOut( void ) throw();
@@ -394,12 +420,16 @@ class RtMidiOut : public RtMidi
       exception is thrown if an error occurs while attempting to make
       the port connection.
   */
-  void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi Output" ) );
+  void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi Output" ) );
 
   //! Close an open MIDI connection (if one exists).
   void closePort( void );
 
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen() const;
 
   //! Create a virtual output port, with optional name, to allow software connections (OS X, JACK and ALSA only).
@@ -411,14 +441,16 @@ class RtMidiOut : public RtMidi
       An exception is thrown if an error occurs while attempting to
       create the virtual port.
   */
-  void openVirtualPort( const std::string portName = std::string( "RtMidi Output" ) );
+  void openVirtualPort( const std::string &portName = std::string( "RtMidi Output" ) );
 
   //! Return the number of available MIDI output ports.
   unsigned int getPortCount( void );
 
   //! Return a string identifier for the specified MIDI port type and number.
   /*!
-      An empty string is returned if an invalid port specifier is provided.
+    \return The name of the port with the given Id is returned.
+    \retval An empty string is returned if an invalid port specifier
+            is provided. User code should assume a UTF-8 encoding.
   */
   std::string getPortName( unsigned int portNumber = 0 );
 
@@ -427,7 +459,17 @@ class RtMidiOut : public RtMidi
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
   */
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
+
+  //! Immediately send a single message out an open MIDI output port.
+  /*!
+      An exception is thrown if an error occurs during output or an
+      output connection was not previously established.
+
+      \param message A pointer to the MIDI message as raw bytes
+      \param size    Length of the MIDI message in bytes
+  */
+  void sendMessage( const unsigned char *message, size_t size );
 
   //! Set an error callback function to be invoked when an error has occured.
   /*!
@@ -437,7 +479,7 @@ class RtMidiOut : public RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );
 
  protected:
-  void openMidiApi( RtMidi::Api api, const std::string clientName );
+  void openMidiApi( RtMidi::Api api, const std::string &clientName );
 };
 
 
@@ -454,16 +496,18 @@ class RtMidiOut : public RtMidi
 //
 // **************************************************************** //
 
-class MidiApi
+class RTMIDI_DLL_PUBLIC MidiApi
 {
  public:
 
   MidiApi();
   virtual ~MidiApi();
   virtual RtMidi::Api getCurrentApi( void ) = 0;
-  virtual void openPort( unsigned int portNumber, const std::string portName ) = 0;
-  virtual void openVirtualPort( const std::string portName ) = 0;
+  virtual void openPort( unsigned int portNumber, const std::string &portName ) = 0;
+  virtual void openVirtualPort( const std::string &portName ) = 0;
   virtual void closePort( void ) = 0;
+  virtual void setClientName( const std::string &clientName ) = 0;
+  virtual void setPortName( const std::string &portName ) = 0;
 
   virtual unsigned int getPortCount( void ) = 0;
   virtual std::string getPortName( unsigned int portNumber ) = 0;
@@ -485,7 +529,7 @@ protected:
   void *errorCallbackUserData_;
 };
 
-class MidiInApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
 {
  public:
 
@@ -498,25 +542,29 @@ class MidiInApi : public MidiApi
 
   // A MIDI structure used internally by the class to store incoming
   // messages.  Each message represents one and only one MIDI message.
-  struct MidiMessage { 
-    std::vector<unsigned char> bytes; 
+  struct MidiMessage {
+    std::vector<unsigned char> bytes;
+
+    //! Time in seconds elapsed since the previous message
     double timeStamp;
 
     // Default constructor.
-  MidiMessage()
-  :bytes(0), timeStamp(0.0) {}
+    MidiMessage()
+      : bytes(0), timeStamp(0.0) {}
   };
 
   struct MidiQueue {
     unsigned int front;
     unsigned int back;
-    unsigned int size;
     unsigned int ringSize;
     MidiMessage *ring;
 
     // Default constructor.
-  MidiQueue()
-  :front(0), back(0), size(0), ringSize(0) {}
+    MidiQueue()
+      : front(0), back(0), ringSize(0), ring(0) {}
+    bool push( const MidiMessage& );
+    bool pop( std::vector<unsigned char>*, double* );
+    unsigned int size( unsigned int *back=0, unsigned int *front=0 );
   };
 
   // The RtMidiInData structure is used to pass private class data to
@@ -534,23 +582,22 @@ class MidiInApi : public MidiApi
     bool continueSysex;
 
     // Default constructor.
-  RtMidiInData()
-  : ignoreFlags(7), doInput(false), firstMessage(true),
-      apiData(0), usingCallback(false), userCallback(0), userData(0),
-      continueSysex(false) {}
+    RtMidiInData()
+      : ignoreFlags(7), doInput(false), firstMessage(true), apiData(0), usingCallback(false),
+        userCallback(0), userData(0), continueSysex(false) {}
   };
 
  protected:
   RtMidiInData inputData_;
 };
 
-class MidiOutApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiOutApi : public MidiApi
 {
  public:
 
   MidiOutApi( void );
   virtual ~MidiOutApi( void );
-  virtual void sendMessage( std::vector<unsigned char> *message ) = 0;
+  virtual void sendMessage( const unsigned char *message, size_t size ) = 0;
 };
 
 // **************************************************************** //
@@ -560,225 +607,27 @@ class MidiOutApi : public MidiApi
 // **************************************************************** //
 
 inline RtMidi::Api RtMidiIn :: getCurrentApi( void ) throw() { return rtapi_->getCurrentApi(); }
-inline void RtMidiIn :: openPort( unsigned int portNumber, const std::string portName ) { rtapi_->openPort( portNumber, portName ); }
-inline void RtMidiIn :: openVirtualPort( const std::string portName ) { rtapi_->openVirtualPort( portName ); }
+inline void RtMidiIn :: openPort( unsigned int portNumber, const std::string &portName ) { rtapi_->openPort( portNumber, portName ); }
+inline void RtMidiIn :: openVirtualPort( const std::string &portName ) { rtapi_->openVirtualPort( portName ); }
 inline void RtMidiIn :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiIn :: isPortOpen() const { return rtapi_->isPortOpen(); }
-inline void RtMidiIn :: setCallback( RtMidiCallback callback, void *userData ) { ((MidiInApi *)rtapi_)->setCallback( callback, userData ); }
-inline void RtMidiIn :: cancelCallback( void ) { ((MidiInApi *)rtapi_)->cancelCallback(); }
+inline void RtMidiIn :: setCallback( RtMidiCallback callback, void *userData ) { static_cast<MidiInApi *>(rtapi_)->setCallback( callback, userData ); }
+inline void RtMidiIn :: cancelCallback( void ) { static_cast<MidiInApi *>(rtapi_)->cancelCallback(); }
 inline unsigned int RtMidiIn :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiIn :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiIn :: ignoreTypes( bool midiSysex, bool midiTime, bool midiSense ) { ((MidiInApi *)rtapi_)->ignoreTypes( midiSysex, midiTime, midiSense ); }
-inline double RtMidiIn :: getMessage( std::vector<unsigned char> *message ) { return ((MidiInApi *)rtapi_)->getMessage( message ); }
+inline void RtMidiIn :: ignoreTypes( bool midiSysex, bool midiTime, bool midiSense ) { static_cast<MidiInApi *>(rtapi_)->ignoreTypes( midiSysex, midiTime, midiSense ); }
+inline double RtMidiIn :: getMessage( std::vector<unsigned char> *message ) { return static_cast<MidiInApi *>(rtapi_)->getMessage( message ); }
 inline void RtMidiIn :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
 inline RtMidi::Api RtMidiOut :: getCurrentApi( void ) throw() { return rtapi_->getCurrentApi(); }
-inline void RtMidiOut :: openPort( unsigned int portNumber, const std::string portName ) { rtapi_->openPort( portNumber, portName ); }
-inline void RtMidiOut :: openVirtualPort( const std::string portName ) { rtapi_->openVirtualPort( portName ); }
+inline void RtMidiOut :: openPort( unsigned int portNumber, const std::string &portName ) { rtapi_->openPort( portNumber, portName ); }
+inline void RtMidiOut :: openVirtualPort( const std::string &portName ) { rtapi_->openVirtualPort( portName ); }
 inline void RtMidiOut :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiOut :: isPortOpen() const { return rtapi_->isPortOpen(); }
 inline unsigned int RtMidiOut :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiOut :: sendMessage( std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
+inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( &message->at(0), message->size() ); }
+inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( message, size ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
-
-// **************************************************************** //
-//
-// MidiInApi and MidiOutApi subclass prototypes.
-//
-// **************************************************************** //
-
-#if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
-  #define __RTMIDI_DUMMY__
-#endif
-
-#if defined(__MACOSX_CORE__)
-
-class MidiInCore: public MidiInApi
-{
- public:
-  MidiInCore( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInCore( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutCore: public MidiOutApi
-{
- public:
-  MidiOutCore( const std::string clientName );
-  ~MidiOutCore( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__UNIX_JACK__)
-
-class MidiInJack: public MidiInApi
-{
- public:
-  MidiInJack( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInJack( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  std::string clientName;
-
-  void connect( void );
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutJack: public MidiOutApi
-{
- public:
-  MidiOutJack( const std::string clientName );
-  ~MidiOutJack( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  std::string clientName;
-
-  void connect( void );
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__LINUX_ALSA__)
-
-class MidiInAlsa: public MidiInApi
-{
- public:
-  MidiInAlsa( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInAlsa( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutAlsa: public MidiOutApi
-{
- public:
-  MidiOutAlsa( const std::string clientName );
-  ~MidiOutAlsa( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__WINDOWS_MM__)
-
-class MidiInWinMM: public MidiInApi
-{
- public:
-  MidiInWinMM( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInWinMM( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutWinMM: public MidiOutApi
-{
- public:
-  MidiOutWinMM( const std::string clientName );
-  ~MidiOutWinMM( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__RTMIDI_DUMMY__)
-
-class MidiInDummy: public MidiInApi
-{
- public:
- MidiInDummy( const std::string /*clientName*/, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit ) { errorString_ = "MidiInDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
-  void openPort( unsigned int /*portNumber*/, const std::string /*portName*/ ) {}
-  void openVirtualPort( const std::string /*portName*/ ) {}
-  void closePort( void ) {}
-  unsigned int getPortCount( void ) { return 0; }
-  std::string getPortName( unsigned int portNumber ) { return ""; }
-
- protected:
-  void initialize( const std::string& /*clientName*/ ) {}
-};
-
-class MidiOutDummy: public MidiOutApi
-{
- public:
-  MidiOutDummy( const std::string /*clientName*/ ) { errorString_ = "MidiOutDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
-  void openPort( unsigned int /*portNumber*/, const std::string /*portName*/ ) {}
-  void openVirtualPort( const std::string /*portName*/ ) {}
-  void closePort( void ) {}
-  unsigned int getPortCount( void ) { return 0; }
-  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
-  void sendMessage( std::vector<unsigned char> * /*message*/ ) {}
-
- protected:
-  void initialize( const std::string& /*clientName*/ ) {}
-};
-
-#endif
 
 #endif

--- a/src/RtMidi/rtmidi_c.cpp
+++ b/src/RtMidi/rtmidi_c.cpp
@@ -1,0 +1,362 @@
+#include <string.h>
+#include <stdlib.h>
+#include "rtmidi_c.h"
+#include "RtMidi.h"
+
+/* Compile-time assertions that will break if the enums are changed in
+ * the future without synchronizing them properly.  If you get (g++)
+ * "error: ‘StaticAssert<b>::StaticAssert() [with bool b = false]’ is
+ * private within this context", it means enums are not aligned. */
+template<bool b> class StaticAssert { private: StaticAssert() {} };
+template<> class StaticAssert<true>{ public: StaticAssert() {} };
+#define ENUM_EQUAL(x,y) StaticAssert<(int)x==(int)y>()
+class StaticAssertions { StaticAssertions() {
+    ENUM_EQUAL( RTMIDI_API_UNSPECIFIED,     RtMidi::UNSPECIFIED );
+    ENUM_EQUAL( RTMIDI_API_MACOSX_CORE,     RtMidi::MACOSX_CORE );
+    ENUM_EQUAL( RTMIDI_API_LINUX_ALSA,      RtMidi::LINUX_ALSA );
+    ENUM_EQUAL( RTMIDI_API_UNIX_JACK,       RtMidi::UNIX_JACK );
+    ENUM_EQUAL( RTMIDI_API_WINDOWS_MM,      RtMidi::WINDOWS_MM );
+    ENUM_EQUAL( RTMIDI_API_RTMIDI_DUMMY,    RtMidi::RTMIDI_DUMMY );
+
+    ENUM_EQUAL( RTMIDI_ERROR_WARNING,            RtMidiError::WARNING );
+    ENUM_EQUAL( RTMIDI_ERROR_DEBUG_WARNING,      RtMidiError::DEBUG_WARNING );
+    ENUM_EQUAL( RTMIDI_ERROR_UNSPECIFIED,        RtMidiError::UNSPECIFIED );
+    ENUM_EQUAL( RTMIDI_ERROR_NO_DEVICES_FOUND,   RtMidiError::NO_DEVICES_FOUND );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_DEVICE,     RtMidiError::INVALID_DEVICE );
+    ENUM_EQUAL( RTMIDI_ERROR_MEMORY_ERROR,       RtMidiError::MEMORY_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_PARAMETER,  RtMidiError::INVALID_PARAMETER );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_USE,        RtMidiError::INVALID_USE );
+    ENUM_EQUAL( RTMIDI_ERROR_DRIVER_ERROR,       RtMidiError::DRIVER_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_SYSTEM_ERROR,       RtMidiError::SYSTEM_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_THREAD_ERROR,       RtMidiError::THREAD_ERROR );
+}};
+
+class CallbackProxyUserData
+{
+  public:
+	CallbackProxyUserData (RtMidiCCallback cCallback, void *userData)
+		: c_callback (cCallback), user_data (userData)
+	{
+	}
+	RtMidiCCallback c_callback;
+	void *user_data;
+};
+
+extern "C" const enum RtMidiApi rtmidi_compiled_apis[]; // casting from RtMidi::Api[]
+extern "C" const unsigned int rtmidi_num_compiled_apis;
+
+/* RtMidi API */
+int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size)
+{
+    unsigned num = rtmidi_num_compiled_apis;
+    if (apis) {
+        num = (num < apis_size) ? num : apis_size;
+        memcpy(apis, rtmidi_compiled_apis, num * sizeof(enum RtMidiApi));
+    }
+    return (int)num;
+}
+
+extern "C" const char* rtmidi_api_names[][2];
+const char *rtmidi_api_name(enum RtMidiApi api) {
+    if (api < 0 || api >= RTMIDI_API_NUM)
+        return NULL;
+    return rtmidi_api_names[api][0];
+}
+
+const char *rtmidi_api_display_name(enum RtMidiApi api)
+{
+    if (api < 0 || api >= RTMIDI_API_NUM)
+        return "Unknown";
+    return rtmidi_api_names[api][1];
+}
+
+enum RtMidiApi rtmidi_compiled_api_by_name(const char *name) {
+    RtMidi::Api api = RtMidi::UNSPECIFIED;
+    if (name) {
+        api = RtMidi::getCompiledApiByName(name);
+    }
+    return (enum RtMidiApi)api;
+}
+
+void rtmidi_error (MidiApi *api, enum RtMidiErrorType type, const char* errorString)
+{
+	std::string msg = errorString;
+	api->error ((RtMidiError::Type) type, msg);
+}
+
+void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName)
+{
+    std::string name = portName;
+    try {
+        ((RtMidi*) device->ptr)->openPort (portNumber, name);
+    
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+    }
+}
+
+void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName)
+{
+    std::string name = portName;
+    try {
+        ((RtMidi*) device->ptr)->openVirtualPort (name);
+    
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+    }
+
+}
+
+void rtmidi_close_port (RtMidiPtr device)
+{
+    try { 
+        ((RtMidi*) device->ptr)->closePort ();
+
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+    }
+}
+
+unsigned int rtmidi_get_port_count (RtMidiPtr device)
+{
+    try {
+        return ((RtMidi*) device->ptr)->getPortCount ();
+
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+        return -1;
+    }
+}
+
+const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber)
+{
+    try {
+        std::string name = ((RtMidi*) device->ptr)->getPortName (portNumber);
+        return strdup (name.c_str ());
+    
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+        return "";
+    }
+}
+
+/* RtMidiIn API */
+RtMidiInPtr rtmidi_in_create_default ()
+{
+    RtMidiWrapper* wrp = new RtMidiWrapper;
+    
+    try {
+        RtMidiIn* rIn = new RtMidiIn ();
+        
+        wrp->ptr = (void*) rIn;
+        wrp->data = 0;
+        wrp->ok  = true;
+        wrp->msg = "";
+    
+    } catch (const RtMidiError & err) {
+        wrp->ptr = 0;
+        wrp->data = 0;
+        wrp->ok  = false;
+        wrp->msg = err.what ();
+    }
+
+    return wrp;
+}
+
+RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsigned int queueSizeLimit)
+{
+    std::string name = clientName;
+    RtMidiWrapper* wrp = new RtMidiWrapper;
+    
+    try {
+        RtMidiIn* rIn = new RtMidiIn ((RtMidi::Api) api, name, queueSizeLimit);
+        
+        wrp->ptr = (void*) rIn;
+        wrp->data = 0;
+        wrp->ok  = true;
+        wrp->msg = "";
+
+    } catch (const RtMidiError & err) {
+        wrp->ptr = 0;
+        wrp->data = 0;
+        wrp->ok  = false;
+        wrp->msg = err.what ();
+    }
+
+    return wrp;
+}
+
+void rtmidi_in_free (RtMidiInPtr device)
+{
+    if (device->data)
+      delete (CallbackProxyUserData*) device->data;
+    delete (RtMidiIn*) device->ptr;
+    delete device;
+}
+
+enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device)
+{
+    try {
+        return (RtMidiApi) ((RtMidiIn*) device->ptr)->getCurrentApi ();
+    
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+
+        return RTMIDI_API_UNSPECIFIED;
+    }
+}
+
+static
+void callback_proxy (double timeStamp, std::vector<unsigned char> *message, void *userData)
+{
+	CallbackProxyUserData* data = reinterpret_cast<CallbackProxyUserData*> (userData);
+	data->c_callback (timeStamp, message->data (), message->size (), data->user_data);
+}
+
+void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void *userData)
+{
+    device->data = (void*) new CallbackProxyUserData (callback, userData);
+    try {
+        ((RtMidiIn*) device->ptr)->setCallback (callback_proxy, device->data);
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+        delete (CallbackProxyUserData*) device->data;
+        device->data = 0;
+    }
+}
+
+void rtmidi_in_cancel_callback (RtMidiInPtr device)
+{
+    try {
+        ((RtMidiIn*) device->ptr)->cancelCallback ();
+        delete (CallbackProxyUserData*) device->data;
+        device->data = 0;
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+    }
+}
+
+void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, bool midiSense)
+{
+	((RtMidiIn*) device->ptr)->ignoreTypes (midiSysex, midiTime, midiSense);
+}
+
+double rtmidi_in_get_message (RtMidiInPtr device, 
+                              unsigned char *message,
+                              size_t *size)
+{
+    try {
+        // FIXME: use allocator to achieve efficient buffering
+        std::vector<unsigned char> v;
+        double ret = ((RtMidiIn*) device->ptr)->getMessage (&v);
+
+        if (v.size () > 0 && v.size() <= *size) {
+            memcpy (message, v.data (), (int) v.size ());
+        }
+
+        *size = v.size();
+        return ret;
+    } 
+    catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+        return -1;
+    }
+    catch (...) {
+        device->ok  = false;
+        device->msg = "Unknown error";
+        return -1;
+    }
+}
+
+/* RtMidiOut API */
+RtMidiOutPtr rtmidi_out_create_default ()
+{
+    RtMidiWrapper* wrp = new RtMidiWrapper;
+
+    try {
+        RtMidiOut* rOut = new RtMidiOut ();
+        
+        wrp->ptr = (void*) rOut;
+        wrp->data = 0;
+        wrp->ok  = true;
+        wrp->msg = "";
+    
+    } catch (const RtMidiError & err) {
+        wrp->ptr = 0;
+        wrp->data = 0;
+        wrp->ok  = false;
+        wrp->msg = err.what ();
+    }
+
+    return wrp;
+}
+
+RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName)
+{
+    RtMidiWrapper* wrp = new RtMidiWrapper;
+    std::string name = clientName;
+
+    try {
+        RtMidiOut* rOut = new RtMidiOut ((RtMidi::Api) api, name);
+        
+        wrp->ptr = (void*) rOut;
+        wrp->data = 0;
+        wrp->ok  = true;
+        wrp->msg = "";
+    
+    } catch (const RtMidiError & err) {
+        wrp->ptr = 0;
+        wrp->data = 0;
+        wrp->ok  = false;
+        wrp->msg = err.what ();
+    }
+
+
+    return wrp;
+}
+
+void rtmidi_out_free (RtMidiOutPtr device)
+{
+    delete (RtMidiOut*) device->ptr;
+    delete device;
+}
+
+enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device)
+{
+    try {
+        return (RtMidiApi) ((RtMidiOut*) device->ptr)->getCurrentApi ();
+
+    } catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+
+        return RTMIDI_API_UNSPECIFIED;
+    }
+}
+
+int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, int length)
+{
+    try {
+        ((RtMidiOut*) device->ptr)->sendMessage (message, length);
+        return 0;
+    }
+    catch (const RtMidiError & err) {
+        device->ok  = false;
+        device->msg = err.what ();
+        return -1;
+    }
+    catch (...) {
+        device->ok  = false;
+        device->msg = "Unknown error";
+        return -1;
+    }
+}

--- a/src/RtMidi/rtmidi_c.h
+++ b/src/RtMidi/rtmidi_c.h
@@ -1,0 +1,246 @@
+/************************************************************************/
+/*! \defgroup C-interface
+    @{
+
+    \brief C interface to realtime MIDI input/output C++ classes.
+
+    RtMidi offers a C-style interface, principally for use in binding
+    RtMidi to other programming languages.  All structs, enums, and
+    functions listed here have direct analogs (and simply call to)
+    items in the C++ RtMidi class and its supporting classes and
+    types
+*/
+/************************************************************************/
+
+/*!
+  \file rtmidi_c.h
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#ifndef RTMIDI_C_H
+#define RTMIDI_C_H
+
+#if defined(RTMIDI_EXPORT)
+#if defined _WIN32 || defined __CYGWIN__
+#define RTMIDIAPI __declspec(dllexport)
+#else
+#define RTMIDIAPI __attribute__((visibility("default")))
+#endif
+#else
+#define RTMIDIAPI //__declspec(dllimport)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//! \brief Wraps an RtMidi object for C function return statuses.
+struct RtMidiWrapper {
+    //! The wrapped RtMidi object.
+    void* ptr;
+    void* data;
+
+    //! True when the last function call was OK. 
+    bool  ok;
+
+    //! If an error occured (ok != true), set to an error message.
+    const char* msg;
+};
+
+//! \brief Typedef for a generic RtMidi pointer.
+typedef struct RtMidiWrapper* RtMidiPtr;
+
+//! \brief Typedef for a generic RtMidiIn pointer.
+typedef struct RtMidiWrapper* RtMidiInPtr;
+
+//! \brief Typedef for a generic RtMidiOut pointer.
+typedef struct RtMidiWrapper* RtMidiOutPtr;
+
+//! \brief MIDI API specifier arguments.  See \ref RtMidi::Api.
+enum RtMidiApi {
+    RTMIDI_API_UNSPECIFIED,    /*!< Search for a working compiled API. */
+    RTMIDI_API_MACOSX_CORE,    /*!< Macintosh OS-X CoreMIDI API. */
+    RTMIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
+    RTMIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
+    RTMIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
+    RTMIDI_API_RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    RTMIDI_API_NUM             /*!< Number of values in this enum. */
+};
+
+//! \brief Defined RtMidiError types. See \ref RtMidiError::Type.
+enum RtMidiErrorType {
+  RTMIDI_ERROR_WARNING,           /*!< A non-critical error. */
+  RTMIDI_ERROR_DEBUG_WARNING,     /*!< A non-critical error which might be useful for debugging. */
+  RTMIDI_ERROR_UNSPECIFIED,       /*!< The default, unspecified error type. */
+  RTMIDI_ERROR_NO_DEVICES_FOUND,  /*!< No devices found on system. */
+  RTMIDI_ERROR_INVALID_DEVICE,    /*!< An invalid device ID was specified. */
+  RTMIDI_ERROR_MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+  RTMIDI_ERROR_INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
+  RTMIDI_ERROR_INVALID_USE,       /*!< The function was called incorrectly. */
+  RTMIDI_ERROR_DRIVER_ERROR,      /*!< A system driver error occured. */
+  RTMIDI_ERROR_SYSTEM_ERROR,      /*!< A system error occured. */
+  RTMIDI_ERROR_THREAD_ERROR       /*!< A thread error occured. */
+};
+
+/*! \brief The type of a RtMidi callback function.
+ *
+ * \param timeStamp   The time at which the message has been received.
+ * \param message     The midi message.
+ * \param userData    Additional user data for the callback.
+ *
+ * See \ref RtMidiIn::RtMidiCallback.
+ */
+typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
+                                 size_t messageSize, void *userData);
+
+
+/* RtMidi API */
+
+/*! \brief Determine the available compiled MIDI APIs.
+ *
+ * If the given `apis` parameter is null, returns the number of available APIs.
+ * Otherwise, fill the given apis array with the RtMidi::Api values.
+ *
+ * \param apis  An array or a null value.
+ * \param apis_size  Number of elements pointed to by apis
+ * \return number of items needed for apis array if apis==NULL, or
+ *         number of items written to apis array otherwise.  A negative
+ *         return value indicates an error.
+ *
+ * See \ref RtMidi::getCompiledApi().
+*/
+RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size);
+
+//! \brief Return the name of a specified compiled MIDI API.
+//! See \ref RtMidi::getApiName().
+RTMIDIAPI const char *rtmidi_api_name(enum RtMidiApi api);
+
+//! \brief Return the display name of a specified compiled MIDI API.
+//! See \ref RtMidi::getApiDisplayName().
+RTMIDIAPI const char *rtmidi_api_display_name(enum RtMidiApi api);
+
+//! \brief Return the compiled MIDI API having the given name.
+//! See \ref RtMidi::getCompiledApiByName().
+RTMIDIAPI enum RtMidiApi rtmidi_compiled_api_by_name(const char *name);
+
+//! \internal Report an error.
+RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);
+
+/*! \brief Open a MIDI port.
+ *
+ * \param port      Must be greater than 0
+ * \param portName  Name for the application port.
+ *
+ * See RtMidi::openPort().
+ */
+RTMIDIAPI void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName);
+
+/*! \brief Creates a virtual MIDI port to which other software applications can 
+ * connect.  
+ *
+ * \param portName  Name for the application port.
+ *
+ * See RtMidi::openVirtualPort().
+ */
+RTMIDIAPI void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName);
+
+/*! \brief Close a MIDI connection.
+ * See RtMidi::closePort().
+ */
+RTMIDIAPI void rtmidi_close_port (RtMidiPtr device);
+
+/*! \brief Return the number of available MIDI ports.
+ * See RtMidi::getPortCount().
+ */
+RTMIDIAPI unsigned int rtmidi_get_port_count (RtMidiPtr device);
+
+/*! \brief Return a string identifier for the specified MIDI input port number.
+ * See RtMidi::getPortName().
+ */
+RTMIDIAPI const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber);
+
+/* RtMidiIn API */
+
+//! \brief Create a default RtMidiInPtr value, with no initialization.
+RTMIDIAPI RtMidiInPtr rtmidi_in_create_default (void);
+
+/*! \brief Create a  RtMidiInPtr value, with given api, clientName and queueSizeLimit.
+ *
+ *  \param api            An optional API id can be specified.
+ *  \param clientName     An optional client name can be specified. This
+ *                        will be used to group the ports that are created
+ *                        by the application.
+ *  \param queueSizeLimit An optional size of the MIDI input queue can be
+ *                        specified.
+ *
+ * See RtMidiIn::RtMidiIn().
+ */
+RTMIDIAPI RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsigned int queueSizeLimit);
+
+//! \brief Free the given RtMidiInPtr.
+RTMIDIAPI void rtmidi_in_free (RtMidiInPtr device);
+
+//! \brief Returns the MIDI API specifier for the given instance of RtMidiIn.
+//! See \ref RtMidiIn::getCurrentApi().
+RTMIDIAPI enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device);
+
+//! \brief Set a callback function to be invoked for incoming MIDI messages.
+//! See \ref RtMidiIn::setCallback().
+RTMIDIAPI void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void *userData);
+
+//! \brief Cancel use of the current callback function (if one exists).
+//! See \ref RtMidiIn::cancelCallback().
+RTMIDIAPI void rtmidi_in_cancel_callback (RtMidiInPtr device);
+
+//! \brief Specify whether certain MIDI message types should be queued or ignored during input.
+//! See \ref RtMidiIn::ignoreTypes().
+RTMIDIAPI void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, bool midiSense);
+
+/*! Fill the user-provided array with the data bytes for the next available
+ * MIDI message in the input queue and return the event delta-time in seconds.
+ *
+ * \param message   Must point to a char* that is already allocated.
+ *                  SYSEX messages maximum size being 1024, a statically
+ *                  allocated array could
+ *                  be sufficient. 
+ * \param size      Is used to return the size of the message obtained. 
+ *
+ * See RtMidiIn::getMessage().
+ */
+RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char *message, size_t *size);
+
+/* RtMidiOut API */
+
+//! \brief Create a default RtMidiInPtr value, with no initialization.
+RTMIDIAPI RtMidiOutPtr rtmidi_out_create_default (void);
+
+/*! \brief Create a RtMidiOutPtr value, with given and clientName.
+ *
+ *  \param api            An optional API id can be specified.
+ *  \param clientName     An optional client name can be specified. This
+ *                        will be used to group the ports that are created
+ *                        by the application.
+ *
+ * See RtMidiOut::RtMidiOut().
+ */
+RTMIDIAPI RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName);
+
+//! \brief Free the given RtMidiOutPtr.
+RTMIDIAPI void rtmidi_out_free (RtMidiOutPtr device);
+
+//! \brief Returns the MIDI API specifier for the given instance of RtMidiOut.
+//! See \ref RtMidiOut::getCurrentApi().
+RTMIDIAPI enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device);
+
+//! \brief Immediately send a single message out an open MIDI output port.
+//! See \ref RtMidiOut::sendMessage().
+RTMIDIAPI int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, int length);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+/*! }@ */

--- a/src/block_implementations/Eos/EosEncoderBlock.h
+++ b/src/block_implementations/Eos/EosEncoderBlock.h
@@ -3,6 +3,7 @@
 
 #include "core/block_data/BlockBase.h"
 #include "core/SmartAttribute.h"
+#include "eos_specific/EosOSCMessage.h"
 #include "midi/MidiManager.h"
 
 
@@ -30,9 +31,12 @@ public:
                         "turn encoder 1 (TYPE) till 'CC' appears and "
                         "encoder 6 (MODE) till 'rel1' appears.<br><br>"
                         "2. Enter the name of the parameter to control in the Block "
-                        "(i.e. 'pan' or 'tilt').<br><br>"
+                        "(it can be 'pan' or 'tilt' or set 'active' option in configuration and "
+                        "use a number (1, 2, ...) of active wheel).<br><br>"
                         "3. At last click 'Learn' above and turn the encoder.<br><br>"
                         "4. (optional) Map a MIDI button to the 'Coarse / Fine' button.<br><br><br>"
+                        "'feedback' checkbox in configuration can be used to control led ring "
+                        "e.g. on Behringer x-touch.<br><br><br>"
                         "This block uses Eos OSC user 1.";
         info.qmlFile = "qrc:/qml/Blocks/Eos/EosEncoderBlock.qml";
         info.complete<EosEncoderBlock>();
@@ -62,6 +66,9 @@ public slots:
     void startLearning();
     void checkIfEventFits(MidiEvent event);
 
+    void onIncomingEosMessage(const EosOSCMessage& msg);
+    void onFeedbackEnabledChanged();
+
     // ------------------------- Getter + Setter -----------------------------
 
     int getTarget() const { return m_target; }
@@ -84,6 +91,9 @@ protected:
 
     StringAttribute m_parameterName;
     BoolAttribute m_fineMode;
+    BoolAttribute m_active;
+    BoolAttribute m_accelerate;
+    BoolAttribute m_feedbackEnabled;
 };
 
 #endif // EOSENCODERBLOCK_H

--- a/src/block_implementations/Eos/EosFaderBankBlock.cpp
+++ b/src/block_implementations/Eos/EosFaderBankBlock.cpp
@@ -18,6 +18,7 @@ EosFaderBankBlock::EosFaderBankBlock(MainController* controller, QString uid)
     , m_feedbackInvalid(m_numFaders, false)
     , m_catchFaders(this, "catchFaders", true)
     , m_pageChangeMode(this, "pageChangeMode", false, false)
+    , m_feedbackEnabled(this, "feedbackEnabled", true)
 {
     connect(m_controller->eosManager(), SIGNAL(connectionEstablished()),
             this, SLOT(onEosConnectionEstablished()));

--- a/src/block_implementations/Eos/EosFaderBankBlock.cpp
+++ b/src/block_implementations/Eos/EosFaderBankBlock.cpp
@@ -1,10 +1,11 @@
 #include "EosFaderBankBlock.h"
 
 #include "core/MainController.h"
+#include "core/Nodes.h"
 
 
 EosFaderBankBlock::EosFaderBankBlock(MainController* controller, QString uid)
-    : BlockBase(controller, uid)
+    : OneOutputBlock(controller, uid)
     , m_bankIndex(QString::number(controller->eosManager()->getNewFaderBankNumber()))
     , m_page(1)
     , m_bankLabel("")
@@ -45,6 +46,7 @@ void EosFaderBankBlock::setPageFromGui(int value) {
     emit faderLevelsChanged();
     sendConfigMessage();
     emit pageChanged();
+    setValue(m_page);
 }
 
 void EosFaderBankBlock::setFaderLabelFromOsc(int faderIndex, QString label) {
@@ -179,6 +181,7 @@ void EosFaderBankBlock::onIncomingEosMessage(const EosOSCMessage& msg) {
         int page = msg.stringValue().toInt();
         if (page >= 1 && page <= 100) {
             m_page = page;
+            setValue(m_page);
             emit pageChanged();
         }
     } else if (msg.pathPart(3) == "name") {
@@ -217,7 +220,10 @@ void EosFaderBankBlock::updateFaderCount() {
     m_faderSync.resize(m_numFaders.getValue());
     m_feedbackInvalid.resize(m_numFaders.getValue());
 
-    sendConfigMessage();
     m_page = 1;
+    setValue(m_page);
     emit pageChanged();
+    m_outputNode->updateConnectionLines();
+
+    sendConfigMessage();
 }

--- a/src/block_implementations/Eos/EosFaderBankBlock.cpp
+++ b/src/block_implementations/Eos/EosFaderBankBlock.cpp
@@ -17,6 +17,7 @@ EosFaderBankBlock::EosFaderBankBlock(MainController* controller, QString uid)
     , m_faderSync(m_numFaders, false)
     , m_feedbackInvalid(m_numFaders, false)
     , m_catchFaders(this, "catchFaders", true)
+    , m_pageChangeMode(this, "pageChangeMode", false, false)
 {
     connect(m_controller->eosManager(), SIGNAL(connectionEstablished()),
             this, SLOT(onEosConnectionEstablished()));

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -98,6 +98,7 @@ protected:
     QVector<bool> m_feedbackInvalid;
 
     BoolAttribute m_catchFaders;
+    BoolAttribute m_pageChangeMode;
     QTime m_lastExtTime;
 };
 

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -107,6 +107,7 @@ protected:
     BoolAttribute m_catchFaders;
     BoolAttribute m_pageChangeMode;
     QTime m_lastExtTime;
+    BoolAttribute m_feedbackEnabled;
 };
 
 #endif // EOSFADERBANKBLOCK_H

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -24,7 +24,14 @@ public:
         info.typeName = "Eos Fader Bank";
         info.nameInUi = "Fader Bank";
         info.category << "ETC Consoles" << "Eos";
-        info.helpText = "A bank of 10 faders.\n\n"
+        info.helpText = "A bank of N faders. N can be set in block settings\n\n"
+                        "'Catch external faders' option will prevent jumping "
+                        "when value gets not synchronized with fader (e.g. on page change)\n\n"
+                        "'Feedback enabled' option controls midi feedback for faders\n\n"
+                        "'Page button' in lower right corner can be mapped to any midi button. "
+                        "Holding the button down and pressing fader stop button jumps to page "
+                        "equal to fader index. With 10 faders you have quick access to 10 pages.\n\n"
+                        "Output node can be used to signal current page to another block.\n\n"
                         "This block uses Eos OSC user 1.";
         info.qmlFile = "qrc:/qml/Blocks/Eos/EosFaderBankBlock.qml";
         info.complete<EosFaderBankBlock>();

--- a/src/block_implementations/Eos/EosFaderBankBlock.h
+++ b/src/block_implementations/Eos/EosFaderBankBlock.h
@@ -4,10 +4,11 @@
 #include <QDateTime>
 #include "core/block_data/BlockBase.h"
 #include "eos_specific/EosOSCMessage.h"
+#include "core/block_data/OneOutputBlock.h"
 #include "utils.h"
 
 
-class EosFaderBankBlock: public BlockBase
+class EosFaderBankBlock: public OneOutputBlock
 {
     Q_OBJECT
 

--- a/src/core/MainController.cpp
+++ b/src/core/MainController.cpp
@@ -15,7 +15,7 @@
 
 #include <string>
 
-MainController::MainController(QQmlApplicationEngine& qmlEngine, QString templateFile, QObject* parent)
+MainController::MainController(QQmlApplicationEngine& qmlEngine, QString templateFile, bool forceImport, QObject* parent)
     : QObject(parent)
     , m_guiManager(this, qmlEngine)
     , m_logManager(this)
@@ -44,6 +44,7 @@ MainController::MainController(QQmlApplicationEngine& qmlEngine, QString templat
     , m_developerMode(false)
     , m_clickSounds(false)
     , m_templateFileToImport(templateFile)
+    , m_forceImport(forceImport)
 {
     // print Qt Version to verify that the right library is loaded:
     qInfo() << "Compiled with Qt Version" << QT_VERSION_STR;
@@ -179,7 +180,7 @@ void MainController::restoreApp() {
     setClickSounds(appState["clickSounds"].toBool());
     m_output.setState(appState["outputManager"].toObject());
 #ifndef Q_OS_ANDROID
-    if (lockExisted) {
+    if (lockExisted && !m_forceImport) {
 #else
     if (false) {
 #endif
@@ -193,9 +194,16 @@ void MainController::restoreApp() {
         m_projectManager.setCurrentProject("empty", /*createIfNotExist*/ true);
     } else if (appState["version"].toDouble() < 0.3) {
         onFirstStart();
-    } else {
+    } else if (m_templateFileToImport.length() > 0 && m_forceImport) {
+        m_projectManager.importProjectFile(m_templateFileToImport, true);
+        m_guiManager.closeTutorialView();
+    }
+    else {
         m_projectManager.setCurrentProject(appState["currentProject"].toString());
     }
+
+    if (m_forceImport)
+        m_guiManager.closeTutorialView();
 }
 
 void MainController::onExit() {

--- a/src/core/MainController.h
+++ b/src/core/MainController.h
@@ -62,6 +62,7 @@ class MainController : public QObject
     Q_PROPERTY(bool developerMode READ getDeveloperMode WRITE setDeveloperMode NOTIFY developerModeChanged)
     Q_PROPERTY(bool clickSounds READ getClickSounds WRITE setClickSounds NOTIFY clickSoundsChanged)
     Q_PROPERTY(QString templateFileToImport READ getTemplateFileBaseName NOTIFY templateFileToImportChanged)
+    Q_PROPERTY(bool forceImport READ getForceImport NOTIFY forceImportChanged)
 
 public:
 
@@ -70,7 +71,8 @@ public:
      * @param qmlEngine is the QML enigne to use to create the GUI
      * @param parent the QObject parent
      */
-    explicit MainController(QQmlApplicationEngine& qmlEngine, QString templateFile, QObject *parent = nullptr);
+    explicit MainController(QQmlApplicationEngine& qmlEngine, QString templateFile,
+                            bool forceImport = false, QObject *parent = nullptr);
 
 
 signals:
@@ -84,6 +86,8 @@ signals:
     void clickSoundsChanged();
 
     void templateFileToImportChanged();
+
+    void forceImportChanged();
 
 
 public slots:
@@ -278,6 +282,8 @@ public slots:
     bool getClickSounds() const { return m_clickSounds; }
     void setClickSounds(bool value) { m_clickSounds = value; emit clickSoundsChanged(); }
 
+    bool getForceImport() const { return m_forceImport; }
+
     QString getTemplateFileBaseName() const;
     void requestTemplateImport(QString filename);
     void onImportTemplateFileAccepted();
@@ -361,6 +367,7 @@ protected:
      */
     QString m_templateFileToImport;
 
+    bool m_forceImport;
 };
 
 #endif // MAINCONTROLLER_H

--- a/src/core/manager/GuiManager.h
+++ b/src/core/manager/GuiManager.h
@@ -51,6 +51,8 @@ signals:
     void overrideGuiScalingChanged();
     void overrideGraphicsLevelChanged();
     void snapToGridChanged();
+    void closeTutorialView();
+    void openTutorialView();
 
 public slots:
 

--- a/src/luminosus.pro
+++ b/src/luminosus.pro
@@ -474,6 +474,10 @@ linux_specific {
 win32:LIBS += -lwinmm
 win64:LIBS += -lwinmm
 
+# msvc needs it
+win32:LIBS += -luser32
+win64:LIBS += -luser32
+
 #include CoreMIDI framework on Mac for RtMidi
 macx:LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
 

--- a/src/luminosus.pro
+++ b/src/luminosus.pro
@@ -481,7 +481,13 @@ macx:LIBS += -framework CoreMIDI -framework CoreAudio -framework CoreFoundation
 !mobile_platform {
     DEFINES += RT_MIDI_AVAILABLE
     SOURCES += RtMidi/RtMidi.cpp
+    SOURCES += RtMidi/rtmidi_c.cpp
     HEADERS += RtMidi/RtMidi.h
+    HEADERS += RtMidi/rtmidi_c.h
+    win32:DEFINES += RTMIDI_EXPORT
+    win32:DEFINES += __WINDOWS_MM__
+    win64:DEFINES += RTMIDI_EXPORT
+    win64:DEFINES += __WINDOWS_MM__
 }
 
 # Android specific files:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,8 +114,13 @@ int main(int argc, char* argv[]) {
 
     QCommandLineParser parser;
     parser.addPositionalArgument("template", "Template to import");
+    parser.addOptions({
+                         {{"f", "force"}, "force import (no warning dialog)"}
+                      });
+    parser.addHelpOption();
     parser.process(app);
     QString templateFile = parser.positionalArguments().size() >= 1 ? parser.positionalArguments().at(0) : "";
+    bool forceImport = parser.isSet("force");
 
     // prepare QML engine:
     qmlRegisterSingletonType(QUrl("qrc:/qml/DefaultStyle.qml"), "CustomStyle", 1, 0, "Style");
@@ -140,7 +145,7 @@ int main(int argc, char* argv[]) {
 	engine.rootContext()->setContextProperty("GRAPHICAL_EFFECTS_LEVEL", GRAPHICAL_EFFECTS_LEVEL);
 
 	// MainController will take care of initalizing GUI, output etc.:
-    MainController controller(engine, templateFile);
+    MainController controller(engine, templateFile, forceImport);
 	QObject::connect(&app, SIGNAL(aboutToQuit()), &controller, SLOT(onExit()));
     QObject::connect(&engine, SIGNAL(quit()), &app, SLOT(quit())); // to make Qt.quit() to work
 

--- a/src/midi/MidiManager.h
+++ b/src/midi/MidiManager.h
@@ -239,6 +239,8 @@ class MidiManager : public QObject {
     Q_PROPERTY(QStringList inputNames READ getInputNames NOTIFY portNamesChanged)
     Q_PROPERTY(QStringList outputNames READ getOutputNames NOTIFY portNamesChanged)
 
+    Q_PROPERTY(bool autoRefresh READ getAutoRefresh WRITE setAutoRefresh NOTIFY autoRefreshChanged)
+
 public:
 	/**
 	 * @brief MidiManager creates a MidiManager that creates MidiInputDevice objects for each Midi device
@@ -257,6 +259,10 @@ public:
 	 * @param state Json object
 	 */
 	void setState(QJsonObject state);
+
+    bool getAutoRefresh() const { return m_autoRefresh; }
+
+    void setAutoRefresh(bool v) { m_autoRefresh = v; emit autoRefreshChanged(); }
 
 signals:
 	/**
@@ -291,6 +297,8 @@ signals:
      * @brief inputNamesChanged emitted when an input was added or removed
      */
     void portNamesChanged();
+
+    void autoRefreshChanged();
 
 public slots:
 
@@ -420,6 +428,8 @@ public slots:
 	 */
 	void clearLog() const { m_log.clear(); emit logChanged(); }
 
+    void switchAutoRefresh();
+
 private:
 	/**
 	 * @brief initializeInputs is called by ctor and creates MidiInputDevice objects for each Midi device
@@ -536,6 +546,12 @@ protected:
      * to prevent the log being updated to often
      */
     mutable QTimer m_logChangedSignalDelay;
+
+    bool m_autoRefresh;
+    int m_hiddenInputPorts;
+    int m_hiddenOutputPorts;
+
+    QTimer m_autoRefreshTimer;
 
 };
 

--- a/src/qml/Blocks/Controls/SliderBlock.qml
+++ b/src/qml/Blocks/Controls/SliderBlock.qml
@@ -27,6 +27,9 @@ BlockBase {
 					block.value = value;
 				}
 			}
+            onExternalValueChanged: {
+                value = externalValue;
+            }
         }
 
         DragArea {

--- a/src/qml/Blocks/Eos/EosEncoderBlock.qml
+++ b/src/qml/Blocks/Eos/EosEncoderBlock.qml
@@ -91,6 +91,42 @@ BlockBase {
                     onPress: block.startLearning()
                 }
             }
+
+            BlockRow {
+                Text {
+                    text: "accelerate:"
+                    width: parent.width - 30*dp
+                }
+                AttributeCheckbox {
+                    width: 30*dp
+                    attr: block.attr("accelerate")
+                }
+            }
+
+            BlockRow {
+                Text {
+                    text: "active:"
+                    width: parent.width - 30*dp
+                }
+                AttributeCheckbox {
+                    width: 30*dp
+                    attr: block.attr("active")
+                }
+            }
+
+            BlockRow {
+                visible: block.attr("active").val === true
+                Text {
+                    text: "feedback:"
+                    width: parent.width - 30*dp
+                }
+                AttributeCheckbox {
+                    width: 30*dp
+                    attr: block.attr("feedback")
+                }
+            }
+
+
         }
     }  // end Settings Component
 }

--- a/src/qml/Blocks/Eos/EosFaderBankBlock.qml
+++ b/src/qml/Blocks/Eos/EosFaderBankBlock.qml
@@ -23,6 +23,7 @@ BlockBase {
 
                 EosFaderItem {
                     index: modelData
+                    feedbackEnabled: block.attr("feedbackEnabled").val
                 }
             }
         }
@@ -105,6 +106,16 @@ BlockBase {
                     width:  55*dp
                     implicitWidth: 0
                     attr: block.attr("numFaders")
+                }
+            }
+            BlockRow {
+                Text {
+                    text: "Feedback enabled:"
+                    width: parent.width - 30*dp
+                }
+                AttributeCheckbox {
+                    width: 30*dp
+                    attr: block.attr("feedbackEnabled")
                 }
             }
         }

--- a/src/qml/Blocks/Eos/EosFaderBankBlock.qml
+++ b/src/qml/Blocks/Eos/EosFaderBankBlock.qml
@@ -31,13 +31,22 @@ BlockBase {
             text: "Fader Bank"
 
             StretchRow {
-                width: 140*dp
+                width: 180*dp
                 height: 30*dp
                 anchors.right: parent.right
                 anchors.rightMargin: 15*dp
-                Text {
-                    width: 60*dp
+
+                ButtonBottomLine {
+                    width: 80*dp
                     text: "Page:"
+                    onActiveChanged: {
+                        if (active) {
+                            block.attr("pageChangeMode").val = true
+                        } else {
+                            block.attr("pageChangeMode").val = false
+                        }
+                    }
+                    mappingID: block.getUid() + "pageChange"
                 }
                 ButtonBottomLine {
                     width: 30*dp

--- a/src/qml/Blocks/Eos/EosFaderBankBlock.qml
+++ b/src/qml/Blocks/Eos/EosFaderBankBlock.qml
@@ -34,6 +34,7 @@ BlockBase {
                 width: 140*dp
                 height: 30*dp
                 anchors.right: parent.right
+                anchors.rightMargin: 15*dp
                 Text {
                     width: 60*dp
                     text: "Page:"
@@ -61,6 +62,10 @@ BlockBase {
                     onPress: block.sendPagePlusEvent()
                     mappingID: block.getUid() + "pagePlus"
                 }
+            }
+
+            OutputNode {
+                node: block.node("outputNode")
             }
         }
 

--- a/src/qml/Blocks/Eos/EosSingleFaderBlock.qml
+++ b/src/qml/Blocks/Eos/EosSingleFaderBlock.qml
@@ -54,6 +54,9 @@ BlockBase {
                     block.setFaderLevelFromGui(value)
                 }
             }
+            onExternalValueChanged: {
+                value = externalValue;
+            }
             mappingID: block.getUid() + "fader"
         }
         PushButton {

--- a/src/qml/CustomControls/Slider.qml
+++ b/src/qml/CustomControls/Slider.qml
@@ -14,6 +14,7 @@ CustomTouchArea {
 	property real indicator: 0.0
     property bool useIndicator: false
     property bool midiMappingEnabled: true
+    property bool feedbackEnabled: true
 
 
     Rectangle {  // grey BG line
@@ -95,5 +96,5 @@ CustomTouchArea {
     onExternalInputChanged: {
         guiManager.setPropertyWithoutChangingBindings(this, "externalValue", externalInput)
     }
-    onValueChanged: controller.midiMapping().sendFeedback(mappingID, value)
+    onValueChanged: if (feedbackEnabled) controller.midiMapping().sendFeedback(mappingID, value)
 }

--- a/src/qml/EosFaderItem.qml
+++ b/src/qml/EosFaderItem.qml
@@ -61,7 +61,17 @@ StretchColumn {
     PushButton {
         implicitHeight: 0  // do not stretch
         height: 40*dp
-        onActiveChanged: block.sendStopEvent(index, active)
+        onActiveChanged: {
+            if (block.attr("pageChangeMode").val === true) {
+                if (active)
+                    block.setPageFromGui(index + 1)
+            }
+            else {
+                block.sendStopEvent(index, active)
+            }
+
+        }
+
         showLed: false
         mappingID: block.getUid() + "stop" + modelData
         Image {

--- a/src/qml/EosFaderItem.qml
+++ b/src/qml/EosFaderItem.qml
@@ -9,6 +9,7 @@ StretchColumn {
     rightMargin: 5*dp
 
     property int index
+    property bool feedbackEnabled: true
 
     Text {
         height: 40*dp
@@ -57,6 +58,7 @@ StretchColumn {
             }
         }
         mappingID: block.getUid() + "fader" + modelData
+        feedbackEnabled: parent.feedbackEnabled
     }
     PushButton {
         implicitHeight: 0  // do not stretch

--- a/src/qml/SettingsComponents/MidiSettings.qml
+++ b/src/qml/SettingsComponents/MidiSettings.qml
@@ -16,6 +16,22 @@ StretchColumn {
 
     BlockRow {
         StretchText {
+            text: "Auto refresh:"
+        }
+        CheckBox {
+            width: 30*dp
+            active: controller.midi().autoRefresh
+            onActiveChanged: {
+                if (active !== controller.midi().autoRefresh) {
+                    controller.midi().autoRefresh = active
+                }
+            }
+        }
+    }
+
+    BlockRow {
+        visible: !controller.midi().autoRefresh
+        StretchText {
             text: "Devices:   " + controller.midi().inputNames.length
         }
         ButtonBottomLine {

--- a/src/qml/SettingsComponents/NewOscPresetArea.qml
+++ b/src/qml/SettingsComponents/NewOscPresetArea.qml
@@ -180,13 +180,44 @@ StretchColumn {
                 text: "OSC Version:"
             }
             ComboBox2 {
-                id: eosUseOsc11Combobox
+                id: eosProtocolComboBox
                 width: 90*dp
                 implicitWidth: 0
                 height: 30*dp
-                values: [false, true]
-                texts: ["1.0", "1.1"]
-                currentIndex: preset.protocol === "TCP 1.1" ? 1 : 0
+                values: controller.lightingConsole().getProtocolNames()
+                currentIndex: Math.max(values.indexOf(preset.protocol), 0)
+            }
+        }
+        StretchRow {
+            height: 30*dp
+            visible: eosProtocolComboBox.currentIndex === 0
+            Text {
+                text: "Tx Port"
+                width: parent.width / 2
+                verticalAlignment: Text.AlignVCenter
+            }
+            NumericInput {
+                id: eosUdpTxInput
+                width: parent.width / 2
+                minimumValue: 0
+                maximumValue: 65535
+                value: preset.udpTxPort || 8001
+            }
+        }
+        StretchRow {
+            height: 30*dp
+            visible: eosProtocolComboBox.currentIndex === 0
+            Text {
+                text: "Rx Port"
+                width: parent.width / 2
+                verticalAlignment: Text.AlignVCenter
+            }
+            NumericInput {
+                id: eosUdpRxInput
+                width: parent.width / 2
+                minimumValue: 0
+                maximumValue: 65535
+                value: preset.udpRxPort || 8000
             }
         }
         StretchRow {
@@ -226,9 +257,9 @@ StretchColumn {
                     Qt.inputMethod.commit()
                     var name = presetNameInput.text
                     var ip = ipInput.text
-                    var protocol = eosUseOsc11Combobox.getValue() ? "TCP 1.1" : "TCP 1.0"
-                    var udpTxPort = 8001
-                    var udpRxPort = 8001
+                    var udpTxPort = eosUdpTxInput.value
+                    var udpRxPort = eosUdpRxInput.value
+                    var protocol = eosProtocolComboBox.getValue()
                     var tcpPort = 3032
                     oscManager.createAndLoadPreset("Eos", name, protocol, ip, udpTxPort, udpRxPort, tcpPort, originalPresetId)
                     closed()

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -479,6 +479,20 @@ Window {
                 visible: parent.mouseOver
             }
         }
+
+        Connections {
+            target: guiManager
+
+            onOpenTutorialView: {
+                if (!tutorialView.open)
+                    tutorialView.open = true
+            }
+            onCloseTutorialView: {
+                if (tutorialView.open)
+                    tutorialView.open = false
+            }
+        }
+
     }
 
     // -------------------------------- Template Import Dialog ---------------------------------
@@ -487,7 +501,7 @@ Window {
         id: templateImportDialog
         title: "Import Template"
         standardButtons: Dialog.Open | Dialog.Cancel
-        visible: controller.templateFileToImport
+        visible: controller.templateFileToImport && !controller.forceImport
 
         onAccepted: {
             controller.onImportTemplateFileAccepted()

--- a/src/version.h
+++ b/src/version.h
@@ -30,7 +30,7 @@ namespace LuminosusVersionInfo {
 	/**
 	 * @brief VERSION_STRING is the version number of this software
 	 */
-	static const QString VERSION_STRING = "1.3.0";
+    static const QString VERSION_STRING = "1.3.1";
 }
 
 #endif // VERSION_H


### PR DESCRIPTION
- fix midi control for slider and eos single fader (regression of catching faders)
- allowed UDP for Eos connection (tcp sometimes includes some lags when using multiple faders and also tcp does not make big sense while running on same machine as nomad)
- allow encoders to control active wheels (`/eos/active/wheel`)
- encoders feedback (eg. led ring on behringer x-touch mini)
- midi devices autorefresh
- option to disable midi feedback on EosFaderBankBlock (can introduce lags and not needed for non motorized faders)
- command line option to force import project without warning